### PR TITLE
Fix GET /homesegment to not attempt sending a response twice

### DIFF
--- a/server/controllers/userSegment.js
+++ b/server/controllers/userSegment.js
@@ -698,7 +698,7 @@ userSegmentRouter.get(
             })
 
             if(!result){
-                res.status(404).json("user segment not found!");
+                return res.status(404).json("user segment not found!");
             }
 
             if(result.homeSegmentId){


### PR DESCRIPTION
Error:
<img width="899" alt="image" src="https://user-images.githubusercontent.com/112919426/236344494-50aafdd9-259d-4746-9ede-e97294ed90d4.png">

Happens because the code continues after the `!result` if clause when it should stop there. Because it doesn't, it complains `result.homeSegmentId` cannot read homeSegmentId of null, then in the finally clause it attempts to send a second response when it already sent one.