### PR TITLE
Reduce Header Component Re-renders

### DIFF
--- a/frontend/src/components/ui/Header.tsx
+++ b/frontend/src/components/ui/Header.tsx
@@ -18,6 +18,7 @@ import { WarningMessageModal } from "../modal/WarningMessageModal";
 import {useBadPostingThreshhold } from 'src/hooks/threshholdHooks';
 
 function Header() {
+  console.log("Header component rendered");
   const [stripeStatus, setStripeStatus] = useState("");
   const { logout, user, token } = useContext(UserProfileContext);
   const { data } = useUserWithJwtVerbose({
@@ -25,7 +26,8 @@ function Header() {
     shouldTrigger: token != null,
   });
   // const { data: googleQuery, isLoading: googleQueryLoading } = useGoogleMapSearchLocation({ lat: data?.geo?.lat, lon: data?.geo?.lon }, (data != null && data.geo != null));
-  const { data: segData, isLoading: segQueryLoading } = useAllUserSegmentsRefined(token, user?.id || null);
+
+  // const { data: segData, isLoading: segQueryLoading } = useAllUserSegmentsRefined(token, user?.id || null);
   const { data: banData, isLoading: banQueryLoading} = FindBanDetailsWithToken(token);
   const { data: badPostingBehaviorData, isLoading: badPostLoading } = FindBadPostingBehaviorDetails(token);
   const {data: badPostingThreshholdData, isLoading: badPostingThreshholdLoading} = useBadPostingThreshhold(token);

--- a/frontend/src/components/ui/Header.tsx
+++ b/frontend/src/components/ui/Header.tsx
@@ -4,26 +4,13 @@ import {
   NavDropdown,
   Nav,
   Navbar,
-  Form,
-  FormControl,
-  Button,
-  Modal,
-  Row,
-  Col,
 } from "react-bootstrap";
-import NavbarCollapse from "react-bootstrap/esm/NavbarCollapse";
 import { useUserWithJwtVerbose } from "src/hooks/userHooks";
 import { UserProfileContext } from "../../contexts/UserProfile.Context";
-import { searchForLocation } from 'src/lib/api/googleMapQuery';
-//import { useGoogleMapSearchLocation } from "src/hooks/googleMapHooks";
-import { useSingleSegmentByName } from "src/hooks/segmentHooks";
-import { findSegmentByName } from "src/lib/api/segmentRoutes";
 import {
-  useAllUserSegments,
   useAllUserSegmentsRefined,
 } from "src/hooks/userSegmentHooks";
 import { getUserSubscriptionStatus } from 'src/lib/api/userRoutes'
-import LoadingSpinner from "./LoadingSpinner";
 import { BanMessageModal } from "../modal/BanMessageModal";
 import { FindBanDetailsWithToken } from "src/hooks/banHooks";
 import { FindBadPostingBehaviorDetails } from "src/hooks/badPostingBehaviorHooks";

--- a/frontend/src/components/ui/Header.tsx
+++ b/frontend/src/components/ui/Header.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { memo, useContext, useEffect, useState } from "react";
 import CSS from "csstype";
 import {
   NavDropdown,
@@ -30,7 +30,7 @@ import { FindBadPostingBehaviorDetails } from "src/hooks/badPostingBehaviorHooks
 import { WarningMessageModal } from "../modal/WarningMessageModal";
 import {useBadPostingThreshhold } from 'src/hooks/threshholdHooks';
 
-export default function Header() {
+function Header() {
   const [stripeStatus, setStripeStatus] = useState("");
   const { logout, user, token } = useContext(UserProfileContext);
   const { data } = useUserWithJwtVerbose({
@@ -258,3 +258,5 @@ export default function Header() {
     </div>
   );
 }
+
+export default memo(Header);

--- a/frontend/src/components/ui/Header.tsx
+++ b/frontend/src/components/ui/Header.tsx
@@ -18,7 +18,6 @@ import { WarningMessageModal } from "../modal/WarningMessageModal";
 import {useBadPostingThreshhold } from 'src/hooks/threshholdHooks';
 
 function Header() {
-  console.log("Header component rendered");
   const [stripeStatus, setStripeStatus] = useState("");
   const { logout, user, token } = useContext(UserProfileContext);
   const { data } = useUserWithJwtVerbose({


### PR DESCRIPTION
Brought down re-render from 9 to 5 times

[abb63c1](https://github.com/MyLivingCity/my-living-city/pull/105/commits/abb63c123b859ca3c9e42ef6f593ee26b94019d1)
- data not used in header in anyway so commented out but should check if its actually needed

Before Header re-rendered 9 times. Reduced down to 5. 
Opinion: not worth optimizing any further at the moment because its relatively quick.
![Screenshot 2023-05-05 at 10 45 24 AM](https://user-images.githubusercontent.com/71413330/236529247-1e9f343f-09bf-4f78-9650-abb8d3992d70.png)
