### PR TITLE
R-008: Implement proposal endorsement list and make it dynamic

### DIFF
--- a/frontend/src/components/content/SingleIdeaPageContent.tsx
+++ b/frontend/src/components/content/SingleIdeaPageContent.tsx
@@ -44,6 +44,7 @@ import DropdownButton from 'react-bootstrap/DropdownButton';
 
 import Form from 'react-bootstrap/Form';
 import { useCheckFlagBan } from "src/hooks/flagHooks";
+import EndorsedUsersSection from '../partials/SingleIdeaContent/EndorsedUsersSection';
 
 interface SingleIdeaPageContentProps {
   ideaData: IIdeaWithRelationship;
@@ -159,8 +160,12 @@ const SingleIdeaPageContent: React.FC<SingleIdeaPageContentProps> = ({
     if (user && token) {
       if (endorsingPost) {
         await unendorseIdeaByUser(token, user.id, ideaId);
+        const newEndorsedUsers = endorsedUsers.filter(u => u.id !== user.id)
+        setEndorsedUsers(newEndorsedUsers);
       } else {
         await endorseIdeaByUser(token, user.id, ideaId);
+        const newEndorsedUsers = [...endorsedUsers, user];
+        setEndorsedUsers(newEndorsedUsers);
       }
       setEndorsingPost(!endorsingPost);
     }
@@ -609,35 +614,10 @@ const SingleIdeaPageContent: React.FC<SingleIdeaPageContentProps> = ({
       </div>
       }
 
-      {(endorsedUsersData && endorsedUsersData.length > 0) ? (
-        <div style={{ marginTop: "2rem" }}>
-        <Card>
-          <Card.Header>
-            <div className="d-flex">
-              <h4 className="h4 p-2 flex-grow-1">Endorse List</h4>
-            </div>
-          </Card.Header>
-          <Card.Body>
-            <Table style={{margin: "0rem"}}>
-              <tbody>
-                {endorsedUsers.map((user) => (
-                  <tr key={user.id}>
-                    <td>
-                      {user.organizationName}
-                    </td>
-                  </tr>
-                ))
-                }
-              </tbody>
-            </Table>
-           </Card.Body>
-        </Card>   
-      </div>
-      ) : null
+      {endorsedUsers && endorsedUsers.length > 0 && 
+        <EndorsedUsersSection endorsedUsers={endorsedUsers}/>
       }
       
-
-
       <Row>
         <RatingsSection ideaId={ideaId} />
       </Row>

--- a/frontend/src/components/content/SingleProposalPageContent.tsx
+++ b/frontend/src/components/content/SingleProposalPageContent.tsx
@@ -64,6 +64,7 @@ import {
 } from "src/lib/api/communityRoutes";
 import { createFlagUnderIdea, updateFalseFlagIdea, compareIdeaFlagsWithThreshold } from "src/lib/api/flagRoutes";
 import { useCheckFlagBan } from 'src/hooks/flagHooks';
+import EndorsedUsersSection from '../partials/SingleIdeaContent/EndorsedUsersSection';
 
 interface SingleIdeaPageContentProps {
   ideaData: IIdeaWithRelationship;
@@ -311,7 +312,6 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
   const [followingPost, setFollowingPost] = useState(false);
   const [endorsingPost, setEndorsingPost] = useState(false);
   const [endorsedUsers, setEndorsedUsers] = useState<any[]>([]);
-  const [endorsedUsersLoading, setEndorsedUsersLoading] = useState(true);
   
   const {data: isFollowingPost, isLoading: isFollowingPostLoading} = useCheckIdeaFollowedByUser(token, (user ? user.id : user), ideaId);
   const {data: isEndorsingPost, isLoading: isEndorsingPostLoading} = useCheckIdeaEndorsedByUser(token, (user ? user.id : user), ideaId);
@@ -323,6 +323,7 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
   || user?.userType == USER_TYPES.MUNICIPAL || user?.userType == USER_TYPES.MUNICIPAL_SEG_ADMIN; 
   const [showEndorseButton, setShowEndorseButton] = useState(false);
   const handleHideEndorseButton = () => setShowEndorseButton(false);
+
   useEffect(() => {
     if (!isEndorsingPostLoading) {
       setEndorsingPost(isEndorsingPost.isEndorsed);
@@ -335,8 +336,12 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
     if (user && token) {
       if (endorsingPost) {
         res = await unendorseIdeaByUser(token, user.id, ideaId);
+        const newEndorsedUsers = endorsedUsers.filter(u => u.id !== user.id)
+        setEndorsedUsers(newEndorsedUsers);
       } else {
         res = await endorseIdeaByUser(token, user.id, ideaId);
+        const newEndorsedUsers = [...endorsedUsers, user];
+        setEndorsedUsers(newEndorsedUsers);
       }
       setEndorsingPost(!endorsingPost);
     }
@@ -345,9 +350,8 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
   useEffect(() => {
     if (!isEndorsedUsersDataLoading) {
       setEndorsedUsers(endorsedUsersData);
-      setEndorsedUsersLoading(false);
     }
-  }, [isEndorsedUsersDataLoading, endorsedUsersData])
+  }, [isEndorsedUsersDataLoading])
 
   const [showFollowButton, setShowFollowButton] = useState(false);
   useEffect(() => {
@@ -1361,37 +1365,13 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
                     </Card.Body>
                   </Card>
                   ) : null}
-
-            
             </Card.Body>
           </Card>
         </div>
       )}
 
-      {endorsedUsersData && endorsedUsersData.length > 0 && (
-        <div style={{ marginTop: "2rem" }}>
-          <Card>
-            <Card.Header>
-              <div className="d-flex">
-                <h4 className="h4 p-2 flex-grow-1">Endorse List</h4>
-              </div>
-            </Card.Header>
-            <Card.Body>
-              <Table style={{margin: "0rem"}}>
-                <tbody>
-                  {endorsedUsers.map((user) => (
-                    <tr key={user.id}>
-                      <td>
-                        {user.organizationName}
-                      </td>
-                    </tr>
-                  ))
-                  }
-                </tbody>
-              </Table>
-            </Card.Body>
-          </Card>   
-        </div>
+      {endorsedUsers && endorsedUsers.length > 0 && (
+        <EndorsedUsersSection endorsedUsers={endorsedUsers}/>
         ) 
       }
 

--- a/frontend/src/components/content/SingleProposalPageContent.tsx
+++ b/frontend/src/components/content/SingleProposalPageContent.tsx
@@ -56,7 +56,7 @@ import {
   unendorseIdeaByUser,
 } from "src/lib/api/ideaRoutes";
 import { incrementPostFlagCount } from 'src/lib/api/badPostingBehaviorRoutes';
-import { useCheckIdeaFollowedByUser, useCheckIdeaEndorsedByUser, useCheckIdeaFlaggedByUser } from "src/hooks/ideaHooks";
+import { useCheckIdeaFollowedByUser, useCheckIdeaEndorsedByUser, useCheckIdeaFlaggedByUser, useGetEndorsedUsersByIdea } from "src/hooks/ideaHooks";
 import {
   postCreateCollabotator,
   postCreateVolunteer,
@@ -310,12 +310,15 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
 
   const [followingPost, setFollowingPost] = useState(false);
   const [endorsingPost, setEndorsingPost] = useState(false);
-
+  const [endorsedUsers, setEndorsedUsers] = useState<any[]>([]);
+  const [endorsedUsersLoading, setEndorsedUsersLoading] = useState(true);
+  
   const {data: isFollowingPost, isLoading: isFollowingPostLoading} = useCheckIdeaFollowedByUser(token, (user ? user.id : user), ideaId);
   const {data: isEndorsingPost, isLoading: isEndorsingPostLoading} = useCheckIdeaEndorsedByUser(token, (user ? user.id : user), ideaId);
   const {data: flagBanData, isLoading: flagBanDataLoading} = useCheckFlagBan(token, (user ? user.id : ""));
   const {data: isFlagged, isLoading: isFlaggedLoading} = useCheckIdeaFlaggedByUser(token, (user ? user.id : user), ideaId);
-
+  const {data: endorsedUsersData, isLoading: isEndorsedUsersDataLoading} = useGetEndorsedUsersByIdea(token, ideaId);
+  
   const canEndorse = user?.userType == USER_TYPES.BUSINESS || user?.userType == USER_TYPES.COMMUNITY 
   || user?.userType == USER_TYPES.MUNICIPAL || user?.userType == USER_TYPES.MUNICIPAL_SEG_ADMIN; 
   const [showEndorseButton, setShowEndorseButton] = useState(false);
@@ -338,6 +341,13 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
       setEndorsingPost(!endorsingPost);
     }
   }
+
+  useEffect(() => {
+    if (!isEndorsedUsersDataLoading) {
+      setEndorsedUsers(endorsedUsersData);
+      setEndorsedUsersLoading(false);
+    }
+  }, [isEndorsedUsersDataLoading, endorsedUsersData])
 
   const [showFollowButton, setShowFollowButton] = useState(false);
   useEffect(() => {
@@ -1357,6 +1367,33 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
           </Card>
         </div>
       )}
+
+      {endorsedUsersData && endorsedUsersData.length > 0 && (
+        <div style={{ marginTop: "2rem" }}>
+          <Card>
+            <Card.Header>
+              <div className="d-flex">
+                <h4 className="h4 p-2 flex-grow-1">Endorse List</h4>
+              </div>
+            </Card.Header>
+            <Card.Body>
+              <Table style={{margin: "0rem"}}>
+                <tbody>
+                  {endorsedUsers.map((user) => (
+                    <tr key={user.id}>
+                      <td>
+                        {user.organizationName}
+                      </td>
+                    </tr>
+                  ))
+                  }
+                </tbody>
+              </Table>
+            </Card.Body>
+          </Card>   
+        </div>
+        ) 
+      }
 
       <Row>
         <RatingsSection ideaId={parsedIdeaId} />

--- a/frontend/src/components/content/SingleProposalPageContent.tsx
+++ b/frontend/src/components/content/SingleProposalPageContent.tsx
@@ -332,14 +332,13 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
   }, [isEndorsingPostLoading, isEndorsingPost])
 
   const handleEndorseUnendorse = async () => {
-    let res;
     if (user && token) {
       if (endorsingPost) {
-        res = await unendorseIdeaByUser(token, user.id, ideaId);
+        await unendorseIdeaByUser(token, user.id, ideaId);
         const newEndorsedUsers = endorsedUsers.filter(u => u.id !== user.id)
         setEndorsedUsers(newEndorsedUsers);
       } else {
-        res = await endorseIdeaByUser(token, user.id, ideaId);
+        await endorseIdeaByUser(token, user.id, ideaId);
         const newEndorsedUsers = [...endorsedUsers, user];
         setEndorsedUsers(newEndorsedUsers);
       }
@@ -1370,9 +1369,8 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
         </div>
       )}
 
-      {endorsedUsers && endorsedUsers.length > 0 && (
+      {endorsedUsers && endorsedUsers.length > 0 && 
         <EndorsedUsersSection endorsedUsers={endorsedUsers}/>
-        ) 
       }
 
       <Row>

--- a/frontend/src/components/partials/SingleIdeaContent/EndorsedUsersSection.tsx
+++ b/frontend/src/components/partials/SingleIdeaContent/EndorsedUsersSection.tsx
@@ -1,0 +1,44 @@
+import React, { useContext, useEffect, useState } from "react";
+import {
+  Card,
+  Row,
+  Table, ButtonGroup,
+} from "react-bootstrap";
+
+interface EndorsedUsersSectionProps {
+  endorsedUsers: any[];
+}
+
+const EndorsedUsersSection: React.FC<EndorsedUsersSectionProps> = ({ endorsedUsers }) => {
+  useEffect(() => {
+
+  }, [endorsedUsers]);
+
+  return (
+    <div style={{ marginTop: "2rem" }}>
+      <Card>
+        <Card.Header>
+          <div className="d-flex">
+            <h4 className="h4 p-2 flex-grow-1">Endorse List</h4>
+          </div>
+        </Card.Header>
+        <Card.Body>
+          <Table style={{margin: "0rem"}}>
+            <tbody>
+              {endorsedUsers.map((user) => (
+                <tr key={user.id}>
+                  <td>
+                    {user.organizationName}
+                  </td>
+                </tr>
+              ))
+              }
+            </tbody>
+          </Table>
+          </Card.Body>
+      </Card>   
+    </div>
+  );
+};
+
+export default EndorsedUsersSection;


### PR DESCRIPTION
**Issue:**
Currently, idea posts have the functionality of showing a list of users who have endorsed the post below the page content. However, this functionality was never implemented in the proposal posts. Furthermore, this endorsement feature does not dynamically change as the user clicks the `Endorse/Unendorse` button, making the state of the page inconsistent with the state of the system. As such, we want to implement this functionality into proposal posts as well as fix the functionality to dynamically change as the user clicks the button.

**Solution:**
As most of the functionality is already implemented into `frontend\src\components\content\SingleIdeaPageContent.tsx`, there wasn't too much that we needed to implement. To make the file cleaner and easier to work with, we took the liberty to extract the content into a separate file `frontend\src\components\partials\SingleIdeaContent\EndorsedUsersSection.tsx`, making it easier for us to implement into the proposal page as well.

After this extraction, we simply import and add the component into `frontend\src\components\content\SingleProposalPageContent.tsx` in the appropriate position, mirroring the location in the idea page.

| State | Preview |
|----|----|
| Proposal Details Before | ![image](https://github.com/MyLivingCity/my-living-city/assets/67846380/c03d4722-132c-4342-b83a-37c18d286291) | 
| Proposal Details After | ![image](https://github.com/MyLivingCity/my-living-city/assets/67846380/7933f6fe-90f4-44c4-8d39-8f3c6fc22761) |


Making the functionality dynamic and synced to the database state was implemented by manipulating the list of endorsements stored on the client side whenever the endorse/unendorse button is clicked, allowing us to accurately reflect our current endorse/unendorsed state.

| The endorsement list dynamically changing as we click the button |
|----|
| ![dynamic_endorse](https://github.com/MyLivingCity/my-living-city/assets/67846380/22655ab3-d646-43d9-8163-312f54001952) |
