### PR TITLE
Remove Submit Rating Component If User Already Rated Idea

### DIFF
--- a/frontend/src/components/partials/SingleIdeaContent/RatingInput.tsx
+++ b/frontend/src/components/partials/SingleIdeaContent/RatingInput.tsx
@@ -47,21 +47,6 @@ const RatingInput = ({
     submitRatingMutation(payload);
   };
 
-  // =================== UTILITY FUNCTIONS FOR UI/AGGREGATIONS ==========================
-  // const parseNegativeRatingValue = (val: number): void => {
-  //   if (userHasRated) return;
-
-  //   let parsedVal = -1 * val;
-  //   setRatingValue(parsedVal);
-  // };
-
-  // const parsePositiveRatingValue = (val: number): void => {
-  //   if (userHasRated) return;
-
-  //   let parsedVal = val - 1;
-  //   setRatingValue(parsedVal);
-  // };
-
   // Loads user submitted rating
   useEffect(() => {
     setRatingValue(userSubmittedRating ?? 0);

--- a/frontend/src/components/partials/SingleIdeaContent/RatingInput.tsx
+++ b/frontend/src/components/partials/SingleIdeaContent/RatingInput.tsx
@@ -102,27 +102,6 @@ const RatingInput = ({
       </style>
       <h2 className="text-center">Submit Your Rating:</h2>
       <Row>
-        {/* <Col xs={12} className="text-center">
-          <Ratings
-            rating={-1 * ratingValue}
-            widgetRatedColors="gold"
-            widgetHoverColors="gold"
-            changeRating={parseNegativeRatingValue}
-          >
-            <Ratings.Widget />
-            <Ratings.Widget />
-          </Ratings>
-          <Ratings
-            rating={ratingValue < 0 ? 0 : ratingValue + 1}
-            widgetRatedColors="gold"
-            widgetHoverColors="gold"
-            changeRating={parsePositiveRatingValue}
-          >
-            <Ratings.Widget widgetHoverColor="gold" widgetRatedColor="gold" />
-            <Ratings.Widget />
-            <Ratings.Widget />
-          </Ratings>
-        </Col> */}
         <Col>
           <div>
             <FormControl

--- a/frontend/src/components/partials/SingleIdeaContent/RatingInput.tsx
+++ b/frontend/src/components/partials/SingleIdeaContent/RatingInput.tsx
@@ -77,6 +77,8 @@ const RatingInput = ({
   };
 
   return (
+    <div>
+    {userHasRated ? (<h2 className="text-center" >You have already rated this idea</h2>): (
     <Container className="">
       <style>
         {`
@@ -164,6 +166,8 @@ const RatingInput = ({
         </Col>
       </Row>
     </Container>
+    )}
+    </div>
   );
 };
 


### PR DESCRIPTION
All rate buttons are removed and replaced with "you have already rated this idea" when a user has rated. 

Before: "Submit your rating" and buttons still exist after rating. (It's just disabled)
![image](https://github.com/MyLivingCity/my-living-city/assets/77481133/dcf329b0-c8e3-4ce7-9ce2-0af302e207e7)

After: Buttons are removed and replaced with "You have already rated this idea" message.
![image](https://github.com/MyLivingCity/my-living-city/assets/77481133/bb8f4aa4-195f-4c59-ad27-f47b8889aad6)

Solution: Added code for the case when userHasRated state is true. 