### PR TITLE
R-002e: Implement and apply AWS S3 image access

### DIFF
--- a/server/controllers/advertisement.js
+++ b/server/controllers/advertisement.js
@@ -2,6 +2,7 @@ const passport = require('passport');
 const express = require('express');
 const advertisementRouter = express.Router();
 const prisma = require('../lib/prismaClient');
+const { imagePathsToS3Url } = require('../lib/utilityFunctions');
 
 const fs = require('fs');
 
@@ -258,6 +259,7 @@ advertisementRouter.get(
     async (req, res) => {
         try {
             const allAd = await prisma.advertisements.findMany({});
+            await imagePathsToS3Url(allAd, "advertisement");
             if (allAd) {
                 return res.status(200).json(allAd);
             } else {
@@ -296,6 +298,7 @@ advertisementRouter.get(
                 }
             });
             if (allAd) {
+                await imagePathsToS3Url(allAd, "advertisement");
                 return res.status(200).json(allAd);
             } else {
                 return res.status(404).send("there's no advertisement belongs to you!");
@@ -331,6 +334,7 @@ advertisementRouter.get(
                 res.status(204).json("adsId not found!");
             }
             if (result) {
+                await imagePathsToS3Url(result, "advertisement");
                 res.status(200).json(result);
             }
         } catch (err) {
@@ -362,6 +366,7 @@ advertisementRouter.get(
                 res.status(204).json("adsId not found!");
             }
             if (result) {
+                await imagePathsToS3Url([result], "advertisement");
                 res.status(200).json(result);
             }
         } catch (err) {
@@ -389,6 +394,7 @@ advertisementRouter.get(
             const result = await prisma.advertisements.findMany({
                 where: { ownerId: ownerId }
             })
+            await imagePathsToS3Url(result, "advertisement");
             res.status(200).json(result);
         } catch (err) {
             console.log(err);

--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -132,10 +132,9 @@ userRouter.get(
 				password: null,
 			};
 
+			await imagePathsToS3Url(parsedUser, "avatar");
 			res.status(200);
-			res.json({
-        ...parsedUser
-			});
+			res.json({...parsedUser});
 		} catch (error) {
 			res.status(400);
 			res.json({
@@ -170,6 +169,7 @@ userRouter.get(
 			}
 
 
+			await imagePathsToS3Url(foundUser, "avatar");
 			res.status(200).json(foundUser);
 		} catch (error) {
 			console.log(error.message);
@@ -201,6 +201,7 @@ userRouter.get(
 					message: "User could not be found or does not exist in the database."
 				});
 			}
+			await imagePathsToS3Url(foundUser, "avatar");
 			res.status(200);
 			res.json({
 				foundUser
@@ -241,6 +242,7 @@ userRouter.get(
 				})
 			}
 
+			await imagePathsToS3Url(foundUser, "avatar");
 			const parsedUser = {
 				...foundUser,
 				password: null,

--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -3,7 +3,7 @@ const express = require('express');
 const userRouter = express.Router();
 const jwt = require('jsonwebtoken');
 const { JWT_SECRET, JWT_EXPIRY } = require('../lib/constants');
-const { argon2ConfirmHash, argon2Hash } = require('../lib/utilityFunctions');
+const { argon2ConfirmHash, argon2Hash, imagePathsToS3Url } = require('../lib/utilityFunctions');
 const prisma = require('../lib/prismaClient');
 const { authenticate } = require('passport');
 
@@ -132,7 +132,7 @@ userRouter.get(
 				password: null,
 			};
 
-			await imagePathsToS3Url(parsedUser, "avatar");
+			await imagePathsToS3Url([parsedUser], "avatar");
 			res.status(200);
 			res.json({...parsedUser});
 		} catch (error) {
@@ -168,8 +168,6 @@ userRouter.get(
 				})
 			}
 
-
-			await imagePathsToS3Url(foundUser, "avatar");
 			res.status(200).json(foundUser);
 		} catch (error) {
 			console.log(error.message);
@@ -201,7 +199,7 @@ userRouter.get(
 					message: "User could not be found or does not exist in the database."
 				});
 			}
-			await imagePathsToS3Url(foundUser, "avatar");
+			await imagePathsToS3Url([foundUser], "avatar");
 			res.status(200);
 			res.json({
 				foundUser
@@ -242,7 +240,7 @@ userRouter.get(
 				})
 			}
 
-			await imagePathsToS3Url(foundUser, "avatar");
+			await imagePathsToS3Url([foundUser], "avatar");
 			const parsedUser = {
 				...foundUser,
 				password: null,

--- a/server/lib/constants.js
+++ b/server/lib/constants.js
@@ -26,6 +26,16 @@ const STRIPE_PRODUCTS = {
   "COMMUNITY":process.env.STRIPE_COMMUNITY_PRODUCT_KEY
 }
 
+// AWS configuration settings for our images bucket
+const AWS_CONFIG = {
+  credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY, // store it in .env file to keep it safe
+      secretAccessKey: process.env.AWS_SECRET_KEY
+  },
+  region: process.env.AWS_REGION // this is the region that you select in AWS account
+};
+const AWS_S3_BUCKET_NAME = process.env.AWS_S3_BUCKET_NAME;
+
 module.exports = {
   // mandatory application configuration
   __prod__,
@@ -38,6 +48,9 @@ module.exports = {
   PROPOSAL_RATING_COUNT,
   PROJECT_RATING_AVG,
   PROJECT_RATING_COUNT,
-  STRIPE_PRODUCTS
+  STRIPE_PRODUCTS,
+  // aws configuration
+  AWS_CONFIG,
+  AWS_S3_BUCKET_NAME,
 }
 

--- a/server/lib/imageBucket.js
+++ b/server/lib/imageBucket.js
@@ -8,7 +8,7 @@ async function uploadImage() {
     // todo
 }
 
-const IMG_EXPIRY_TIME = 10;
+const IMG_EXPIRY_TIME = 60; // in seconds
 async function accessImage(imageFolder, imageKey) {
     const command = new GetObjectCommand({
         Bucket: AWS_S3_BUCKET_NAME,

--- a/server/lib/imageBucket.js
+++ b/server/lib/imageBucket.js
@@ -1,13 +1,29 @@
-const AWS = require("aws-sdk");
+const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
+const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
+const { AWS_CONFIG, AWS_S3_BUCKET_NAME } = require("./constants");
+
+const client = new S3Client(AWS_CONFIG);
 
 async function uploadImage() {
     // todo
 }
 
-async function accessImage() {
-    // todo
+const IMG_EXPIRY_TIME = 10;
+async function accessImage(imageFolder, imageKey) {
+    const command = new GetObjectCommand({
+        Bucket: AWS_S3_BUCKET_NAME,
+        Key: `${imageFolder}/${imageKey}`,
+    });
+
+    return await getSignedUrl(client, command, { expiresIn: IMG_EXPIRY_TIME });
 }
 
 async function deleteImage() {
     // todo
 }
+
+module.exports = { 
+    uploadImage, 
+    accessImage, 
+    deleteImage 
+};

--- a/server/lib/imageBucket.js
+++ b/server/lib/imageBucket.js
@@ -9,6 +9,14 @@ async function uploadImage() {
 }
 
 const IMG_EXPIRY_TIME = 60; // in seconds
+/**
+ * Requests a signed URL for an image from the AWS S3 bucket. The URL expires
+ * within a specified amonut of time.
+ * 
+ * @param { string } imageFolder    The folder path the image resides in
+ * @param { string } imageKey       The name of the image
+ * @returns { string }              The pre-signed url
+ */
 async function accessImage(imageFolder, imageKey) {
     const command = new GetObjectCommand({
         Bucket: AWS_S3_BUCKET_NAME,

--- a/server/lib/utilityFunctions.js
+++ b/server/lib/utilityFunctions.js
@@ -1,4 +1,5 @@
 const argon2 = require('argon2');
+const { accessImage } = require('./imageBucket');
 
 /**
  * Hashes a plain text string using argon2 hashing algorithm.
@@ -32,7 +33,16 @@ const argon2ConfirmHash = async (string, hash) => {
   }
 }
 
+const imagePathsToS3Url = async (items, itemType) => {
+  await Promise.all(items.map(async (item) => {
+    if (item.imagePath) {
+      item.imagePath = await accessImage(itemType, item.imagePath);
+    }
+  }));
+}
+
 module.exports = {
   argon2Hash,
   argon2ConfirmHash,
+  imagePathsToS3Url
 }

--- a/server/lib/utilityFunctions.js
+++ b/server/lib/utilityFunctions.js
@@ -41,7 +41,7 @@ const argon2ConfirmHash = async (string, hash) => {
  * @param { string } itemType The item type we want to process
  */
 const imagePathsToS3Url = async (items, itemType) => {
-  const validPaths = Set(["advertisement", "idea-proposal", "avatar"]);
+  const validPaths = new Set(["advertisement", "idea-proposal", "avatar"]);
   if (!validPaths.has(itemType)) {
     console.log("Invalid item type for image path conversion.");
     return;

--- a/server/lib/utilityFunctions.js
+++ b/server/lib/utilityFunctions.js
@@ -33,7 +33,20 @@ const argon2ConfirmHash = async (string, hash) => {
   }
 }
 
+/**
+ * Reassigns the image paths of a list of objects to their AWS S3 bucket URLs.
+ * Assumes that the item type is either "advertisement", "idea-proposal", or "avatar".
+ * 
+ * @param { Array } items     The list of items to re-assign image paths to
+ * @param { string } itemType The item type we want to process
+ */
 const imagePathsToS3Url = async (items, itemType) => {
+  const validPaths = Set(["advertisement", "idea-proposal", "avatar"]);
+  if (!validPaths.has(itemType)) {
+    console.log("Invalid item type for image path conversion.");
+    return;
+  }
+
   await Promise.all(items.map(async (item) => {
     if (item.imagePath) {
       item.imagePath = await accessImage(itemType, item.imagePath);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.332.0",
+        "@aws-sdk/s3-request-presigner": "^3.332.0",
         "@prisma/client": "^2.30.3",
         "@types/nodemailer": "^6.4.1",
         "argon2": "^0.27.1",
@@ -73,6 +75,1331 @@
       },
       "peerDependencies": {
         "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+      "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+      "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.329.0.tgz",
+      "integrity": "sha512-hzrjPNQcJoSPe0oS20V5i98oiEZSM3mKNiR6P3xHTHTPI/F23lyjGZ+/CSkCmJbSWfGZ5sHZZcU6AWuS7xBdTw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/chunked-blob-reader": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.310.0.tgz",
+      "integrity": "sha512-CrJS3exo4mWaLnWxfCH+w88Ou0IcAZSIkk4QbmxiHl/5Dq705OLoxf4385MVyExpqpeVJYOYQ2WaD8i/pQZ2fg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.332.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.332.0.tgz",
+      "integrity": "sha512-4AkbBPGjFkIvN15l9uDHcry3kwMknpl0b7mqFaNQqQJR2OyFJnr7US/KyeTjwijJAuU+f7lKz8QMTtBcghJm3w==",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "3.0.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.332.0",
+        "@aws-sdk/config-resolver": "3.329.0",
+        "@aws-sdk/credential-provider-node": "3.332.0",
+        "@aws-sdk/eventstream-serde-browser": "3.329.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.329.0",
+        "@aws-sdk/eventstream-serde-node": "3.329.0",
+        "@aws-sdk/fetch-http-handler": "3.329.0",
+        "@aws-sdk/hash-blob-browser": "3.329.0",
+        "@aws-sdk/hash-node": "3.329.0",
+        "@aws-sdk/hash-stream-node": "3.329.0",
+        "@aws-sdk/invalid-dependency": "3.329.0",
+        "@aws-sdk/md5-js": "3.329.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.329.0",
+        "@aws-sdk/middleware-content-length": "3.329.0",
+        "@aws-sdk/middleware-endpoint": "3.329.0",
+        "@aws-sdk/middleware-expect-continue": "3.329.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.331.0",
+        "@aws-sdk/middleware-host-header": "3.329.0",
+        "@aws-sdk/middleware-location-constraint": "3.329.0",
+        "@aws-sdk/middleware-logger": "3.329.0",
+        "@aws-sdk/middleware-recursion-detection": "3.329.0",
+        "@aws-sdk/middleware-retry": "3.329.0",
+        "@aws-sdk/middleware-sdk-s3": "3.329.0",
+        "@aws-sdk/middleware-serde": "3.329.0",
+        "@aws-sdk/middleware-signing": "3.329.0",
+        "@aws-sdk/middleware-ssec": "3.329.0",
+        "@aws-sdk/middleware-stack": "3.329.0",
+        "@aws-sdk/middleware-user-agent": "3.332.0",
+        "@aws-sdk/node-config-provider": "3.329.0",
+        "@aws-sdk/node-http-handler": "3.329.0",
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/signature-v4-multi-region": "3.329.0",
+        "@aws-sdk/smithy-client": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
+        "@aws-sdk/util-defaults-mode-node": "3.329.0",
+        "@aws-sdk/util-endpoints": "3.332.0",
+        "@aws-sdk/util-retry": "3.329.0",
+        "@aws-sdk/util-stream-browser": "3.329.0",
+        "@aws-sdk/util-stream-node": "3.331.0",
+        "@aws-sdk/util-user-agent-browser": "3.329.0",
+        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.329.0",
+        "@aws-sdk/xml-builder": "3.310.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.332.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.332.0.tgz",
+      "integrity": "sha512-4q1Nko8M6YVANdEiLYvdv1qb00j4xN4ppE/6d4xpGp7DxHYlm0GA762h0/TR2dun+2I+SMnwj4Fv6BxOmzBaEw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.329.0",
+        "@aws-sdk/fetch-http-handler": "3.329.0",
+        "@aws-sdk/hash-node": "3.329.0",
+        "@aws-sdk/invalid-dependency": "3.329.0",
+        "@aws-sdk/middleware-content-length": "3.329.0",
+        "@aws-sdk/middleware-endpoint": "3.329.0",
+        "@aws-sdk/middleware-host-header": "3.329.0",
+        "@aws-sdk/middleware-logger": "3.329.0",
+        "@aws-sdk/middleware-recursion-detection": "3.329.0",
+        "@aws-sdk/middleware-retry": "3.329.0",
+        "@aws-sdk/middleware-serde": "3.329.0",
+        "@aws-sdk/middleware-stack": "3.329.0",
+        "@aws-sdk/middleware-user-agent": "3.332.0",
+        "@aws-sdk/node-config-provider": "3.329.0",
+        "@aws-sdk/node-http-handler": "3.329.0",
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/smithy-client": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
+        "@aws-sdk/util-defaults-mode-node": "3.329.0",
+        "@aws-sdk/util-endpoints": "3.332.0",
+        "@aws-sdk/util-retry": "3.329.0",
+        "@aws-sdk/util-user-agent-browser": "3.329.0",
+        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.332.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.332.0.tgz",
+      "integrity": "sha512-tz8k8Yqm4TScIfit0Tum2zWAq1md+gZKr747CSixd4Zwcp7Vwh75cRoL7Rz1ZHSEn1Yo983MWREevVez3SubLw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.329.0",
+        "@aws-sdk/fetch-http-handler": "3.329.0",
+        "@aws-sdk/hash-node": "3.329.0",
+        "@aws-sdk/invalid-dependency": "3.329.0",
+        "@aws-sdk/middleware-content-length": "3.329.0",
+        "@aws-sdk/middleware-endpoint": "3.329.0",
+        "@aws-sdk/middleware-host-header": "3.329.0",
+        "@aws-sdk/middleware-logger": "3.329.0",
+        "@aws-sdk/middleware-recursion-detection": "3.329.0",
+        "@aws-sdk/middleware-retry": "3.329.0",
+        "@aws-sdk/middleware-serde": "3.329.0",
+        "@aws-sdk/middleware-stack": "3.329.0",
+        "@aws-sdk/middleware-user-agent": "3.332.0",
+        "@aws-sdk/node-config-provider": "3.329.0",
+        "@aws-sdk/node-http-handler": "3.329.0",
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/smithy-client": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
+        "@aws-sdk/util-defaults-mode-node": "3.329.0",
+        "@aws-sdk/util-endpoints": "3.332.0",
+        "@aws-sdk/util-retry": "3.329.0",
+        "@aws-sdk/util-user-agent-browser": "3.329.0",
+        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.332.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.332.0.tgz",
+      "integrity": "sha512-uVobnXIzMcEhwBDyk6iOt36N/TRNI8hwq7MQugjYGj7Inma9g4vnR09hXJ24HxyKCoVUoIgMbEguQ43+/+uvDQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.329.0",
+        "@aws-sdk/credential-provider-node": "3.332.0",
+        "@aws-sdk/fetch-http-handler": "3.329.0",
+        "@aws-sdk/hash-node": "3.329.0",
+        "@aws-sdk/invalid-dependency": "3.329.0",
+        "@aws-sdk/middleware-content-length": "3.329.0",
+        "@aws-sdk/middleware-endpoint": "3.329.0",
+        "@aws-sdk/middleware-host-header": "3.329.0",
+        "@aws-sdk/middleware-logger": "3.329.0",
+        "@aws-sdk/middleware-recursion-detection": "3.329.0",
+        "@aws-sdk/middleware-retry": "3.329.0",
+        "@aws-sdk/middleware-sdk-sts": "3.329.0",
+        "@aws-sdk/middleware-serde": "3.329.0",
+        "@aws-sdk/middleware-signing": "3.329.0",
+        "@aws-sdk/middleware-stack": "3.329.0",
+        "@aws-sdk/middleware-user-agent": "3.332.0",
+        "@aws-sdk/node-config-provider": "3.329.0",
+        "@aws-sdk/node-http-handler": "3.329.0",
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/smithy-client": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
+        "@aws-sdk/util-defaults-mode-node": "3.329.0",
+        "@aws-sdk/util-endpoints": "3.332.0",
+        "@aws-sdk/util-retry": "3.329.0",
+        "@aws-sdk/util-user-agent-browser": "3.329.0",
+        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.329.0.tgz",
+      "integrity": "sha512-Oj6eiT3q+Jn685yvUrfRi8PhB3fb81hasJqdrsEivA8IP8qAgnVUTJzXsh8O2UX8UM2MF6A1gTgToSgneJuw2Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.329.0.tgz",
+      "integrity": "sha512-B4orC9hMt9hG82vAR0TAnQqjk6cFDbO2S14RdzUj2n2NPlGWW4Blkv3NTo86K0lq011VRhtqaLcuTwn5EJD5Sg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.329.0.tgz",
+      "integrity": "sha512-ggPlnd7QROPTid0CwT01TYYGvstRRTpzTGsQ/B31wkh30IrRXE81W3S4xrOYuqQD3u0RnflSxnvhs+EayJEYjg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.329.0",
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/url-parser": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.332.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.332.0.tgz",
+      "integrity": "sha512-DTW6d6rcqizPVyvcIrwvxecQ7e5GONtVc5Wyf0RTfqf41sDOVZYmn6G+zEFSpBLW0975uZbJS0lyLWtJe2VujQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.329.0",
+        "@aws-sdk/credential-provider-imds": "3.329.0",
+        "@aws-sdk/credential-provider-process": "3.329.0",
+        "@aws-sdk/credential-provider-sso": "3.332.0",
+        "@aws-sdk/credential-provider-web-identity": "3.329.0",
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/shared-ini-file-loader": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.332.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.332.0.tgz",
+      "integrity": "sha512-KkBayS9k4WyJTvC86ngeRM+RmWxNCS1BHvudkR6PLXfnsNPDzxySDVY0UgxVhbNYDYsO561fXZt9ccpKyVWjgg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.329.0",
+        "@aws-sdk/credential-provider-imds": "3.329.0",
+        "@aws-sdk/credential-provider-ini": "3.332.0",
+        "@aws-sdk/credential-provider-process": "3.329.0",
+        "@aws-sdk/credential-provider-sso": "3.332.0",
+        "@aws-sdk/credential-provider-web-identity": "3.329.0",
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/shared-ini-file-loader": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.329.0.tgz",
+      "integrity": "sha512-5oO220qoFc2pMdZDQa6XN/mVhp669I3+LqMbbscGtX/UgLJPSOb7YzPld9Wjv12L5rf+sD3G1PF3LZXO0vKLFA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/shared-ini-file-loader": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.332.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.332.0.tgz",
+      "integrity": "sha512-SaKXl48af3n6LRitcaEqbeg1YDXwQ0A5QziC1xQyYPraEIj3IZ/GyTjx04Lo2jxNYHuEOE8u4aTw1+IK1GDKbg==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.332.0",
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/shared-ini-file-loader": "3.329.0",
+        "@aws-sdk/token-providers": "3.332.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.329.0.tgz",
+      "integrity": "sha512-lcEibZD7AlutCacpQ6DyNUqElZJDq+ylaIo5a8MH9jGh7Pg2WpDg0Sy+B6FbGCkVn4eIjdHxeX54JM245nhESg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.329.0.tgz",
+      "integrity": "sha512-1r+6MNfye0za35FNLxMR5V9zpKY1lyzwySyu7o7aj8lnStBaCcjOEe7iHboP/z3DH73KJbxR++O2N+UC/XHFrg==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-browser": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.329.0.tgz",
+      "integrity": "sha512-oWFSn4o6sxlbFF0AIuDJYf7N0fkiOyWvYgRW3VTX9FSbd66f/KnDspdxIasaDPDUzJl5YRMwUvQbPWw8y9ZQfQ==",
+      "dependencies": {
+        "@aws-sdk/eventstream-serde-universal": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.329.0.tgz",
+      "integrity": "sha512-iQguqvTtxWXAIniaWmmAO0Qy8080fqnS309p9jbYzz7KaT90sNSCX+CxGFHPy5F0QY36uklDdHn1d1fwWTZciA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-node": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.329.0.tgz",
+      "integrity": "sha512-+DFia0wdZiHpdOKjBcl1baZjtzPKf4U4MvOpsUpC6CeW1kSy0hoikKzJstNvRb1qxrTSamElT4gKkMHxxVhPBQ==",
+      "dependencies": {
+        "@aws-sdk/eventstream-serde-universal": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.329.0.tgz",
+      "integrity": "sha512-n9UzW6HKAhVD5wuz3FMC1ew3VI/vUvRSPXGUpKReMiR2z+YyjmuW8UM4nn7q6i7A/I4QHBt1TC/ax/J2yupgPg==",
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.329.0.tgz",
+      "integrity": "sha512-9jfIeJhYCcTX4ScXOueRTB3S/tVce0bRsKxKDP0PnTxnGYOwKXoM9lAPmiYItzYmQ/+QzjTI8xfkA9Usz2SK/Q==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/querystring-builder": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-blob-browser": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.329.0.tgz",
+      "integrity": "sha512-F5HwXYYSpJtUJqmCRKbz/xwDdOyxKpu69TlfsliECLvAQiQGMh2GO1wGm7grolgTROVVqLYRKk2TSJl/WBg1pw==",
+      "dependencies": {
+        "@aws-sdk/chunked-blob-reader": "3.310.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.329.0.tgz",
+      "integrity": "sha512-6RmnWXNWpi7yAs0oRDQlkMn2wfXOStr/8kTCgiAiqrk1KopGSBkC2veKiKRSfv02FTd1yV/ISqYNIRqW1VLyxg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-stream-node": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.329.0.tgz",
+      "integrity": "sha512-blSZcb/hJyw3c1bH2Hc1aRoRgruNhRK/qc2svq5kXQFW+qBI5O4fwJayKSdo62/Wh2ejR/N06teYQ9haQLVJEA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.329.0.tgz",
+      "integrity": "sha512-UXynGusDxN/HxLma5ByJ7u+XnuMd47NbHOjJgYsaAjb1CVZT7hEPXOB+mcZ+Ku7To5SCOKu2QbRn7m4bGespBg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.329.0.tgz",
+      "integrity": "sha512-newSeHd+CO2hNmXhQOrUk5Y1hH7BsJ5J4IldcqHKY93UwWqvQNiepRowSa2bV5EuS1qx3kfXhD66PFNRprrIlQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.329.0.tgz",
+      "integrity": "sha512-h3/JdK+FmJ/nxLcd8QciJYLy0B4QRsYqqxSffXJ7DYlDjEhUgvVpfGdVgAYHrTtOP8rHSG/K7l7iY7QqTaZpuw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-arn-parser": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.329.0.tgz",
+      "integrity": "sha512-7kCd+CvY/4KbyXB0uyL7jCwPjMi2yERMALFdEH9dsUciwmxIQT6eSc4aF6wImC4UrbafaqmXvvHErABKMVBTKA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.329.0.tgz",
+      "integrity": "sha512-hdJRoNdCM0BT4W+rrtee+kfFRgGPGXQDgtbIQlf/FuuuYz2sdef7/SYWr0mxuncnVBW5WkYSPP8h6q07whSKbg==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/util-middleware": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.329.0.tgz",
+      "integrity": "sha512-E/Jp2KijdR/BwF4s899xcSN4/bbHqYznwmBRL5PiHI+HImA6aZ11qTP8kPt5U5p0l2j5iTmW3FpMnByQKJP5Dw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.331.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.331.0.tgz",
+      "integrity": "sha512-rdRa4yvyqSQ/HDCh4p1Glv8Y/uRNuIwmOG4nDuL6/GYK1BQdpUpbgrhsszPormku10SnbAdsaWGmVhy3qlUSCQ==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-crypto/crc32c": "3.0.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.329.0.tgz",
+      "integrity": "sha512-JrHeUdTIpTCfXDo9JpbAbZTS1x4mt63CCytJRq0mpWp+FlP9hjckBcNxWdR/wSKEzP9pDRnTri638BOwWH7O8w==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.329.0.tgz",
+      "integrity": "sha512-iUTkyXyhchqoEPkdMZSkHhRQmXe0El1+r9oOw8y9JN6IY0T1bnaqUlerGXzb/tQUeENk9OXYuvDHExegHjEWug==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.329.0.tgz",
+      "integrity": "sha512-lKeeTXsYC1NiwmxrXsZepcwNXPoQxTNNbeD1qaCELPGK2cJlrGoeAP2YRWzpwO2kNZWrDLaGAPT/EUEhqw+d1w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.329.0.tgz",
+      "integrity": "sha512-0/TYOJwrj1Z8s+Y7thibD23hggBq/K/01NwPk32CwWG/G+1vWozs5DefknEl++w0vuV+39pkY4KHI8m/+wOCpg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.329.0.tgz",
+      "integrity": "sha512-cB3D7GlhHUcHGOlygOYxD9cPhwsTYEAMcohK38An8+RHNp6VQEWezzLFCmHVKUSeCQ+wkjZfPA40jOG0rbjSgQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/service-error-classification": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/util-retry": "3.329.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.329.0.tgz",
+      "integrity": "sha512-Uo8dLXLDpOb3BnLVl0mkTPiVXlNzNGOXOVtpihvYhF2Z+hGFJW1Ro3aUDbVEsFHu753r2Lss4dLiq1fzREeBKA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-arn-parser": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.329.0.tgz",
+      "integrity": "sha512-bqtZuhkH8pANb2Gb4FEM1p27o+BoDBmVhEWm8sWH+APsyOor3jc6eUG2GxkfoO6D5tGNIuyCC/GuvW9XDIe4Kg==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.329.0.tgz",
+      "integrity": "sha512-tvM9NdPuRPCozPjTGNOeYZeLlyx3BcEyajrkRorCRf1YzG/mXdB6I1stote7i4q1doFtYTz0sYL8bqW3LUPn9A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.329.0.tgz",
+      "integrity": "sha512-bL1nI+EUcF5B1ipwDXxiKL+Uw02Mbt/TNX54PbzunBGZIyO6DZG/H+M3U296bYbvPlwlZhp26O830g6K7VEWsA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/signature-v4": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-middleware": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.329.0.tgz",
+      "integrity": "sha512-XtDA/P2Sf79scu4a7tG77QC3VLtAGq/pit73x+qwctnI4gBgZlQ+FpE15d89ulntd7rIaD4v6tVU0bAg/L3PIQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.329.0.tgz",
+      "integrity": "sha512-2huFLhJ45td2nuiIOjpc9JKJbFNn5CYmw9U8YDITTcydpteRN62CzCpeqroDvF89VOLWxh0ZFtuLCGUr7liSWQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.332.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.332.0.tgz",
+      "integrity": "sha512-rSL1xP4QmcMOsunN1p5ZDR9GT3vvoSCnYa4iPvMSjP8Jx7l4ff/aVctwfZkMs/up12+68Jqwj4TvtaCvCFXdUA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-endpoints": "3.332.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.329.0.tgz",
+      "integrity": "sha512-hg9rGNlkzh8aeR/sQbijrkFx2BIO53j4Z6qDxPNWwSGpl05jri1VHxHx2HZMwgbY6Zy/DSguETN/BL8vdFqyLg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/shared-ini-file-loader": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.329.0.tgz",
+      "integrity": "sha512-OrjaHjU2ZTPfoHa5DruRvTIbeHH/cc0wvh4ml+FwDpWaPaBpOhLiluhZ3anqX1l5QjrXNiQnL8FxSM5OV/zVCA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.329.0",
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/querystring-builder": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.329.0.tgz",
+      "integrity": "sha512-1cHLTV6yyMGaMSWWDW/p4vTkJ1cc5BOEO+A0eHuAcoSOk+LDe9IKhUG3/ZOvvYKQYcqIj5jjGSni/noXNCl/qw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.329.0.tgz",
+      "integrity": "sha512-0rLEHY6QTHTUUcVxzGbPUSmCKlXWplxT/fcYRh0bcc5MBK4naKfcQft1O6Ajp8uqs/9YPZ7XCVCn90pDeJfeaw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.329.0.tgz",
+      "integrity": "sha512-UWgMKkS5trliaDJG4nPv3onu8Y0aBuwRo7RdIgggguOiU8pU6pq1I113nH2FBNWy+Me1bwf+bcviJh0pCo6bEg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.329.0.tgz",
+      "integrity": "sha512-9mkK+FB7snJ2G7H3CqtprDwYIRhzm6jEezffCwUWrC+lbqHBbErbhE9IeU/MKxILmf0RbC2riXEY1MHGspjRrQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.332.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.332.0.tgz",
+      "integrity": "sha512-+gqb/Ce9LNCdwsUvZYyge382WX+l4qUPRmOiEx6tSorKcfHSA8259AN5obeg/6b+YjUhqQaQlB85ed8kd9m6zQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-endpoint": "3.329.0",
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/signature-v4-multi-region": "3.329.0",
+        "@aws-sdk/smithy-client": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-format-url": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.329.0.tgz",
+      "integrity": "sha512-TSNr0flOcCLe71aPp7MjblKNGsmxpTU4xR5772MDX9Cz9GUTNZCPFtvrcqd+wzEPP/AC7XwNXe8KjoXooZImUQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.329.0.tgz",
+      "integrity": "sha512-e0hyd75fbjMd4aCoRwpP2/HR+0oScwogErVArIkq3F42c/hyNCQP3sph4JImuXIjuo6HNnpKpf20CEPPhNna8A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.329.0.tgz",
+      "integrity": "sha512-9EnLoyOD5nFtCRAp+QRllDgQASCfY7jLHVhwht7jzwE80wE65Z9Ym5Z/mwTd4IyTz/xXfCvcE2VwClsBt0Ybdw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.329.0.tgz",
+      "integrity": "sha512-SiK1ez8Ns61ulDm0MJsTOSGNJNOMNoPgfA9i+Uu/VMCBkotZASuxrcSWW8seQnLEynWLerjUF9CYpCQuCqKn9w==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.329.0",
+        "@aws-sdk/signature-v4": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/signature-v4-crt": "^3.118.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/signature-v4-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.329.0.tgz",
+      "integrity": "sha512-7E0fGpBKxwFqHHAOqNbgNsHSEmCZLuvmU9yvG9DXKVzrS4P48O/PfOro123WpcFZs3STyOVgH8wjUPftHAVKmg==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.332.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.332.0.tgz",
+      "integrity": "sha512-fccbg6OSl0l658pxl2p1MoU9gEePo5B361+JNaN0zfRMu7c5HBXCpdl4djlFxAHjltrX9f1+BKqfGHYgI3h8SQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.332.0",
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/shared-ini-file-loader": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.329.0.tgz",
+      "integrity": "sha512-wFBW4yciDfzQBSFmWNaEvHShnSGLMxSu9Lls6EUf6xDMavxSB36bsrVRX6CyAo/W0NeIIyEOW1LclGPgJV1okg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.329.0.tgz",
+      "integrity": "sha512-/VcfL7vNJKJGSjYYHVQF3bYCDFs4fSzB7j5qeVDwRdWr870gE7O1Dar+sLWBRKFF3AX+4VzplqzUfpu9t44JVA==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
+      "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.329.0.tgz",
+      "integrity": "sha512-2iSiy/pzX3OXMhtSxtAzOiEFr3viQEFnYOTeZuiheuyS+cea2L79F6SlZ1110b/nOIU/UOrxxtz83HVad8YFMQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.329.0.tgz",
+      "integrity": "sha512-7A6C7YKjkZtmKtH29isYEtOCbhd7IcXPP8lftN8WAWlLOiZE4gV7PHveagUj7QserJzgRKGwwTQbBj53n18HYg==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.329.0",
+        "@aws-sdk/credential-provider-imds": "3.329.0",
+        "@aws-sdk/node-config-provider": "3.329.0",
+        "@aws-sdk/property-provider": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.332.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.332.0.tgz",
+      "integrity": "sha512-nQx7AiOroMU2hj6h+umWOSZ+WECwxupaxFUK/PPKGW6NY/VdQE6LluYnXOtF5awlr8w1nPksT0Lq05PZutMDLA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.329.0.tgz",
+      "integrity": "sha512-FMokjI10Vzpfb+jeJ0y6TnutPcyessdEz6aKMwn5Ee8etnHaEVDXf5tp8bPZ5ii5WRWwgNNrAa+IkJ2KH4E43g==",
+      "dependencies": {
+        "@aws-sdk/querystring-builder": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.329.0.tgz",
+      "integrity": "sha512-RhBOBaxzkTUghi4MSqr8S5qeeBCjgJ0XPJ6jIYkVkj1saCmqkuZCgl3zFaYdyhdxxPV6nflkFer+1HUoqT+Fqw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.329.0.tgz",
+      "integrity": "sha512-+3VQ9HZLinysnmryUs9Xjt1YVh4TYYHLt30ilu4iUnIHFQoamdzIbRCWseSVFPCxGroen9M9qmAleAsytHEKuA==",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.329.0.tgz",
+      "integrity": "sha512-UF1fJNfgrdJLMxn8ZlfPkYdv7hoLvVgSk3GHgxYA4OQs5zKCzeZgVrbxtE147LxWwJbxi3Qf04vnaEHwzVESpg==",
+      "dependencies": {
+        "@aws-sdk/fetch-http-handler": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node": {
+      "version": "3.331.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.331.0.tgz",
+      "integrity": "sha512-5YUatdh4vgkv7VFY+lSkF+b+6EFkiHvy+dlucfGoJEOcEzuA/NBZYebWbcJ5TiR6z3cQdA23OTyZz3ZofZY1hw==",
+      "dependencies": {
+        "@aws-sdk/node-http-handler": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.329.0.tgz",
+      "integrity": "sha512-8hLSmMCl8aw2++0Zuba8ELq8FkK6/VNyx470St201IpMn2GMbQMDl/rLolRKiTgji6wc+T3pOTidkJkz8/cIXA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.329.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.329.0.tgz",
+      "integrity": "sha512-C50Zaeodc0+psEP+L4WpElrH8epuLWJPVN4hDOTORcM0cSoU2o025Ost9mbcU7UdoHNxF9vitLnzORGN9SHolg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.329.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.329.0.tgz",
+      "integrity": "sha512-MIGs7snNL0ZV55zo1BDVPlrmbinUGV3260hp6HrW4zUbpYVoeIOGeewtrwAsF6FJ+vpZCxljPBB0X2jYR7Q7ZQ==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.329.0",
+        "@aws-sdk/types": "3.329.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
+      "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@jsdevtools/ono": {
@@ -365,6 +1692,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/boxen": {
       "version": "4.2.0",
@@ -1188,6 +2520,21 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -2359,6 +3706,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.0.tgz",
+      "integrity": "sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==",
+      "peer": true
+    },
     "node_modules/opencollective-postinstall": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
@@ -3068,6 +4421,11 @@
         "node": "^8.1 || >=10.*"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3228,6 +4586,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/type-fest": {
       "version": "0.8.1",

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,8 @@
   },
   "homepage": "https://github.com/MyLivingCity/my-living-city#readme",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.332.0",
+    "@aws-sdk/s3-request-presigner": "^3.332.0",
     "@prisma/client": "^2.30.3",
     "@types/nodemailer": "^6.4.1",
     "argon2": "^0.27.1",


### PR DESCRIPTION
**Problem**:
Since we're switching our image storage to AWS, we want to be able to get the image URLs from the back-end to display on the front-end for each request. As such, we want to update our server to return URLs that we can send to the client to display to the user.

**Areas Changed**: Back-end (Server)

**Solution**:
We utilize the `aws-sdk` module to request for presigned URLs, which are essentially URLs that give access for a predefined amount of time. We have implemented an `accessImage(imageFolder, imageKey)` function within our `imageBucket` module to serve as a general-purpose image access request based on what folder and image we want to grab. We have also implemented a helper function called `imagePathsToS3Url(items, itemType)` that serves to reassign the image paths of a list of objects to the AWS presigned URLs.

| Before |
|----|
|![image](https://github.com/MyLivingCity/my-living-city/assets/67846380/0e7f6313-7498-44b0-b31d-f9a36a68772a)|

| After |
|----|
|![image](https://github.com/MyLivingCity/my-living-city/assets/67846380/9cf8fd3b-882c-42d2-bc72-2f0e3621f857)|

Currently, we have the image links set to expire in 60 seconds, but this can be adjusted if need be.

The routes impacted include:
- Idea
  - `/idea/getall`
  - `/idea/getall/with-sort`
  - `/idea/get/:ideaId`
  - `/idea/get/proposal/:supportingProposalId`
  - `/idea/getAllEndorsedByUser/:userId`
- Advertisement
  - `/advertisement/getAll`
  - `/advertisement/getAllPublished`
  - `/advertisement/getAllUser/:userId`
  - `/advertisement/get/:adsId`
  - `/advertisement/getAdsByOwner/:ownerId`
- User
  - `/user/me`
  - `/user/me-verbose`
  - `/user/email/:email`

All routes are tested using Postman since the front-end hasn't been updated to utilize the new URLs and assumes that images are placed within the appropriate S3 bucket with the file path `<image folder>/<unix time>-<image name>.<image extension>`. 

