### PR TITLE
R-002f: Implement and apply AWS S3 image deletion

### DIFF
--- a/server/controllers/advertisement.js
+++ b/server/controllers/advertisement.js
@@ -3,8 +3,7 @@ const express = require('express');
 const advertisementRouter = express.Router();
 const prisma = require('../lib/prismaClient');
 const { imagePathsToS3Url } = require('../lib/utilityFunctions');
-const {uploadImage, makeUpload} = require('../lib/imageBucket');
-const fs = require('fs');
+const {uploadImage, makeUpload, deleteImage} = require('../lib/imageBucket');
 const { isEmpty } = require('lodash');
 
 require('dotenv').config();
@@ -58,7 +57,7 @@ advertisementRouter.post(
                     const theBasicAd = await prisma.advertisements.findFirst({ where: { ownerId: id, adType: 'BASIC' } });
 
                     if (theBasicAd) {
-                        await uploadImage(folderName, fileName, fileContent);
+                        await deleteImage("advertisement", imagePath);
                         return res.status(400).json({ message: `You already created a basic advertisement, if you want to create more, please select type "EXTRA"; you can edit or delete the current basic advertisement.` });
                     }
                 }
@@ -137,10 +136,8 @@ advertisementRouter.post(
 
                 //If there's error in error holder
                 if (error && errorMessage && errorStack) {
-                    //multer is a kind of middleware, if file is valid, multer will add it to upload folder. Following code are responsible for deleting files if error happened.
-                    if (fs.existsSync(imagePath)) {
-                        fs.unlinkSync(imagePath);
-                    }
+                    await deleteImage("advertisement", imagePath); // delet image if it already exists
+
                     let tempError = error;
                     let tempErrorMessage = errorMessage;
                     let tempErrorStack = errorStack;
@@ -481,11 +478,8 @@ advertisementRouter.put(
 
                 //If there's error in error holder
                 if (error && errorMessage && errorStack) {
-                    //multer is a kind of middleware, if file is valid, multer will add it to upload folder. Following code are responsible for deleting files if error happened.
                     if (req.file) {
-                        if (fs.existsSync(req.file.path)) {
-                            fs.unlinkSync(req.file.path);
-                        }
+                        await deleteImage("advertisement", req.file.path); // delete image if creation process errored
                     }
                     let tempError = error;
                     let tempErrorMessage = errorMessage;
@@ -511,9 +505,7 @@ advertisementRouter.put(
                 }
                 let newImagePath;
                 if (req.file) {
-                    if (fs.existsSync(theAdvertisement.imagePath)) {
-                        fs.unlinkSync(theAdvertisement.imagePath);
-                    }
+                    await deleteImage("advertisement", theAdvertisement.imagePath);
                     newImagePath = req.file.path;
                 }
 
@@ -584,11 +576,8 @@ advertisementRouter.delete(
                     res.status(404).send("Advertisement which needs to be deleted not found!");
                 } else {
                     if (theAdvertisement.ownerId === loggedInUserId) {
-
-                        if (fs.existsSync(theAdvertisement.imagePath)) {
-                            fs.unlinkSync(theAdvertisement.imagePath);
-                        };
-
+                        await deleteImage("advertisement", theAdvertisement.imagePath);
+                        
                         await prisma.advertisements.delete({
                             where: {
                                 id: parsedAdvertisementId

--- a/server/controllers/advertisement.js
+++ b/server/controllers/advertisement.js
@@ -567,7 +567,7 @@ advertisementRouter.delete(
                 select: { userType: true }
             });
 
-            if (theUser.userType == 'ADMIN' || theUser.userType == 'BUSINESS') {
+            if (theUser.userType === 'ADMIN' || theUser.userType === 'BUSINESS') {
                 const theAdvertisement = await prisma.advertisements.findUnique({
                     where: { id: parsedAdvertisementId }
                 })
@@ -578,13 +578,15 @@ advertisementRouter.delete(
                     if (theAdvertisement.ownerId === loggedInUserId) {
                         await deleteImage("advertisement", theAdvertisement.imagePath);
                         
-                        await prisma.advertisements.delete({
+                        const deletedAd = await prisma.advertisements.delete({
                             where: {
                                 id: parsedAdvertisementId
                             }
                         });
-
-                        res.sendStatus(204);
+                        res.status(200).json({
+                            message: "Advertisement succesfully deleted",
+                            deletedAd: deletedAd,
+                        });
                     } else {
                         return res.status(401).json({
                             message: `The user ${email} is not the author or an admin and therefore cannot delete this advertisement.`

--- a/server/controllers/avatar.js
+++ b/server/controllers/avatar.js
@@ -63,10 +63,7 @@ avatarRouter.get(
             }
           });
 
-          if(fs.existsSync(originalPath)){
-            fs.unlinkSync(originalPath);
-          }
-
+          await deleteImage("avatar", originalPath);
           res.status(200).json(result);
     
         } catch (error) {

--- a/server/controllers/idea.js
+++ b/server/controllers/idea.js
@@ -970,10 +970,12 @@ ideaRouter.delete(
         await deleteImage("idea-proposal", foundIdea.imagePath);
       }
 
-      const deleteComment = await prisma.ideaComment.deleteMany({ where: { ideaId: foundIdea.id } });
-      const deleteRating = await prisma.ideaRating.deleteMany({ where: { ideaId: foundIdea.id } });
-      const deletedGeo = await prisma.ideaGeo.deleteMany({ where: { ideaId: foundIdea.id } });
-      const deleteAddress = await prisma.ideaAddress.deleteMany({ where: { ideaId: foundIdea.id } });
+      await prisma.ideaComment.deleteMany({ where: { ideaId: foundIdea.id } });
+      await prisma.ideaRating.deleteMany({ where: { ideaId: foundIdea.id } });
+      await prisma.ideaGeo.deleteMany({ where: { ideaId: foundIdea.id } });
+      await prisma.ideaAddress.deleteMany({ where: { ideaId: foundIdea.id } });
+      await prisma.userIdeaEndorse.deleteMany({ where: { ideaId: foundIdea.id } });
+      await prisma.proposal.deleteMany({ where: { ideaId: foundIdea.id } });
       const deletedIdea = await prisma.idea.delete({ where: { id: parsedIdeaId } });
 
       res.status(200).json({

--- a/server/controllers/idea.js
+++ b/server/controllers/idea.js
@@ -5,6 +5,7 @@ const ideaRouter = express.Router();
 const prisma = require('../lib/prismaClient');
 const { checkIdeaThresholds } = require('../lib/prismaFunctions');
 const { imagePathsToS3Url } = require('../lib/utilityFunctions');
+const { deleteImage } = require('../lib/imageBucket');
 const { isInteger, isEmpty } = require('lodash');
 
 const {uploadImage, makeUpload} = require('../lib/imageBucket');
@@ -187,10 +188,7 @@ ideaRouter.post(
 
         //If there's error in error holder
         if (error || errorMessage || errorStack) {
-          //multer is a kind of middleware, if file is valid, multer will add it to upload folder. Following code are responsible for deleting files if error happened.
-          if (fs.existsSync(imagePath)) {
-            fs.unlinkSync(imagePath);
-          }
+          await deleteImage("idea-proposal", imagePath); // delete image if idea/proposal creation errors out
           return res.status(400).json({
             message: error,
             details: {
@@ -956,7 +954,7 @@ ideaRouter.delete(
       const foundIdea = await prisma.idea.findUnique({ where: { id: parsedIdeaId } });
       if (!foundIdea) {
         return res.status(400).json({
-          message: `The idea with that listed ID (${ideaId}) does not exist.`,
+          message: `The idea with that listed ID (${parsedIdeaId}) does not exist.`,
         });
       }
 
@@ -969,9 +967,7 @@ ideaRouter.delete(
       }
 
       if (foundIdea.imagePath) {
-        if (fs.existsSync(foundIdea.imagePath)) {
-          fs.unlinkSync(foundIdea.imagePath);
-        }
+        await deleteImage("idea-proposal", foundIdea.imagePath);
       }
 
       const deleteComment = await prisma.ideaComment.deleteMany({ where: { ideaId: foundIdea.id } });

--- a/server/controllers/proposal.js
+++ b/server/controllers/proposal.js
@@ -537,14 +537,11 @@ proposalRouter.delete(
             }
 
             if (foundProposal.imagePath) {
-                if (fs.existsSync(foundProposal.imagePath)) {
-                    fs.unlinkSync(foundProposal.imagePath);
-                }
+                await deleteImage("idea-proposal", foundProposal.imagePath);
             }
 
             const deleteComment = await prisma.ideaComment.deleteMany({ where: { ideaId: foundProposal.id } });
             const deleteRating = await prisma.ideaRating.deleteMany({ where: { ideaId: foundProposal.id } });
-
             const deletedGeo = await prisma.ideaGeo.deleteMany({ where: { ideaId: foundProposal.id } });
             const deleteAddress = await prisma.ideaAddress.deleteMany({ where: { ideaId: foundProposal.id } });
             const deletedProposal = await prisma.idea.delete({ where: { id: parsedProposalId } });

--- a/server/controllers/proposal.js
+++ b/server/controllers/proposal.js
@@ -6,6 +6,7 @@ const prisma = require('../lib/prismaClient');
 
 const fs = require('fs');
 const { collaborator } = require('../lib/prismaClient');
+const { deleteImage } = require('../lib/imageBucket');
 
 // post request to create a proposal
 proposalRouter.post(
@@ -524,7 +525,7 @@ proposalRouter.delete(
             const foundProposal = await prisma.idea.findUnique({ where: { id: parsedProposalId } });
             if (!foundProposal) {
                 return res.status(400).json({
-                    message: `The idea with that listed ID (${ideaId}) does not exist.`,
+                    message: `The idea with that listed ID (${parsedProposalId}) does not exist.`,
                 });
             }
 
@@ -540,10 +541,12 @@ proposalRouter.delete(
                 await deleteImage("idea-proposal", foundProposal.imagePath);
             }
 
-            const deleteComment = await prisma.ideaComment.deleteMany({ where: { ideaId: foundProposal.id } });
-            const deleteRating = await prisma.ideaRating.deleteMany({ where: { ideaId: foundProposal.id } });
-            const deletedGeo = await prisma.ideaGeo.deleteMany({ where: { ideaId: foundProposal.id } });
-            const deleteAddress = await prisma.ideaAddress.deleteMany({ where: { ideaId: foundProposal.id } });
+            await prisma.ideaComment.deleteMany({ where: { ideaId: foundProposal.id } });
+            await prisma.ideaRating.deleteMany({ where: { ideaId: foundProposal.id } });
+            await prisma.ideaGeo.deleteMany({ where: { ideaId: foundProposal.id } });
+            await prisma.ideaAddress.deleteMany({ where: { ideaId: foundProposal.id } });
+            await prisma.userIdeaEndorse.deleteMany({ where: { ideaId: foundProposal.id } });
+            await prisma.proposal.deleteMany({ where: { ideaId: foundProposal.id } });
             const deletedProposal = await prisma.idea.delete({ where: { id: parsedProposalId } });
 
             res.status(200).json({

--- a/server/lib/imageBucket.js
+++ b/server/lib/imageBucket.js
@@ -1,5 +1,3 @@
-//required modules for uploading image to s3 bucket
-
 const multer = require('multer');
 const multerS3 = require('multer-s3');
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");

--- a/server/lib/imageBucket.js
+++ b/server/lib/imageBucket.js
@@ -3,7 +3,7 @@
 const multer = require('multer');
 const multerS3 = require('multer-s3');
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
-const { S3Client, GetObjectCommand, PutObjectCommand } = require("@aws-sdk/client-s3");
+const { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } = require("@aws-sdk/client-s3");
 const { AWS_CONFIG, AWS_S3_BUCKET_NAME } = require("./constants");
 
 const client = new S3Client(AWS_CONFIG);
@@ -64,16 +64,38 @@ const IMG_EXPIRY_TIME = 60; // in seconds
  * @returns { string }              The pre-signed url
  */
 async function accessImage(imageFolder, imageKey) {
-    const command = new GetObjectCommand({
-        Bucket: AWS_S3_BUCKET_NAME,
-        Key: `${imageFolder}/${imageKey}`,
-    });
+    try {
+        const command = new GetObjectCommand({
+            Bucket: AWS_S3_BUCKET_NAME,
+            Key: `${imageFolder}/${imageKey}`,
+        });
 
-    return await getSignedUrl(client, command, { expiresIn: IMG_EXPIRY_TIME });
+        return await getSignedUrl(client, command, { expiresIn: IMG_EXPIRY_TIME });
+    } catch (err) {
+        console.log("Error generating signed url for image: ", err);
+    }
 }
 
-async function deleteImage() {
-    // todo
+/**
+ * Removes the image from the S3 bucket and inserts a delete marker where the image was.
+ * Returns a "success" message regardless of whether something has been deleted.
+ * 
+ * @param { string } imageFolder            The folder path the image resides in
+ * @param { string } imageKey               The name of the image
+ * @returns { DeleteMarker: true || false, 
+ *            VersionId: "STRING_VALUE", 
+ *            RequestCharged: "requester" } The deletion response from AWS
+ */
+async function deleteImage(imageFolder, imageKey) {
+    try {
+        const command = new DeleteObjectCommand({
+            Bucket: AWS_S3_BUCKET_NAME,
+            Key: `${imageFolder}/${imageKey}`,
+        });
+        return await client.send(command);
+    } catch (err) {
+        console.log("Error deleting image: ", err);
+    }
 }
 
 module.exports = { 


### PR DESCRIPTION
**Problem**:
Since we're switching our image storage to AWS, we want to be able to delete images from our AWS S3 bucket whenever the specified resource (avatar, advertisement, and idea/proposal images) is deleted. As such, we want to update our server to utilize the `aws-sdk` to delete images from the bucket when necessary.

**Areas Changed**: 
Back-end (Server)

**Solution**:
We utilize the `aws-sdk` module to send object deletion requests whenever the related resource is deleted, making sure that we're not storing any images that aren't being used anywhere in the database. This is implemented through a function in the `imageBucket.js` module called `deleteImage(folderName, imageName)` that handles this implementation. This is applied by simply adding this deletion request on every route that involves deleting a `user`, `advertisement`, or `idea`/`proposal`. The deletion request returns a success code regardless of whether the object was existing/was deleted from the bucket, so adding the function call shouldn't cause any new issues.

The routes impacted include:
- Advertisement
  - `POST advertisement/create`
  - `PUT advertisement/update/:advertisementId`
  - `DELETE advertisement/delete/:advertisementId`
- Avatar
  - `POST avatar/image`
- Idea
  - `POST idea/create`
  - `DELETE idea/delete/:ideaId`
- Proposal
  - `DELETE proposal/delete/:ideaId`

We've also noticed that the deletion routes for `idea` and `proposal` weren't working properly due to the schema not cascading to other dependent tables upon delete, so we've applied a quick band-aid fix by deleting the required rows before deleting the specified idea/proposal. However, we should apply a schema change to cascade upon deletion to increase code maintainability and reduce the number of manual deletes we need to do with every schema change.

**Testing**:
All routes are tested using Postman since the front end hasn't been updated to utilize the new URLs and assumes that images are placed within the appropriate S3 bucket with the file path `<image folder>/<unix time>-<image name>.<image extension>`. 

When testing the deletion routes the respective file must then be uploaded into AWS S3 under the appropriate file name and folder for deletion. Then, the rows within `idea`, `advertisement`, and/or `avatar` for the item in question must be manually changed through DBeaver or some other way so that the image name matches the name of the image stored within the AWS S3 bucket. 

