### PR TITLE
R-002h: Update image URLs with pre-signed URLs

### DIFF
--- a/frontend/src/components/content/AllAdsPageContent.tsx
+++ b/frontend/src/components/content/AllAdsPageContent.tsx
@@ -87,7 +87,7 @@ const AllAdsPageContent: React.FC<AllAdsPageContentProps> = ({
                 <td>
                   <img
                     alt=""
-                    src={`${API_BASE_URL}/${item.imagePath}`}
+                    src={item.imagePath}
                     height="100rem"
                   ></img>
                 </td>

--- a/frontend/src/components/content/ProfileContent.tsx
+++ b/frontend/src/components/content/ProfileContent.tsx
@@ -393,7 +393,7 @@ const ProfileContent: React.FC<ProfileContentProps> = ({ user, token }) => {
                 {imagePath ? (
                   <Image
                     fluid
-                    src={`${API_BASE_URL}/${imagePath}`}
+                    src={imagePath}
                     style={{
                       objectFit: "cover",
                       height: "200px",
@@ -688,7 +688,7 @@ const ProfileContent: React.FC<ProfileContentProps> = ({ user, token }) => {
                 {imagePath ? (
                   <Image
                     fluid
-                    src={`${API_BASE_URL}/${imagePath}`}
+                    src={imagePath}
                     style={{
                       objectFit: "cover",
                       height: "200px",
@@ -979,7 +979,7 @@ const ProfileContent: React.FC<ProfileContentProps> = ({ user, token }) => {
                 {imagePath ? (
                   <Image
                     fluid
-                    src={`${API_BASE_URL}/${imagePath}`}
+                    src={imagePath}
                     style={{
                       objectFit: "cover",
                       height: "200px",

--- a/frontend/src/components/content/SingleIdeaPageContent.tsx
+++ b/frontend/src/components/content/SingleIdeaPageContent.tsx
@@ -258,7 +258,7 @@ const SingleIdeaPageContent: React.FC<SingleIdeaPageContentProps> = ({
       <Card>
         {imagePath ? (
           <Image
-            src={`${API_BASE_URL}/${imagePath}`}
+            src={imagePath}
             style={{ objectFit: "cover", height: "400px" }}
           ></Image>
         ) : null}

--- a/frontend/src/components/content/SingleProposalPageContent.tsx
+++ b/frontend/src/components/content/SingleProposalPageContent.tsx
@@ -441,7 +441,7 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
       <Card>
         {imagePath ? (
           <Image
-            src={`${API_BASE_URL}/${imagePath}`}
+            src={imagePath}
             style={{ objectFit: "cover", height: "400px" }}
           ></Image>
         ) : null}

--- a/frontend/src/components/partials/LandingContent/AdsSection.tsx
+++ b/frontend/src/components/partials/LandingContent/AdsSection.tsx
@@ -31,7 +31,7 @@ const AdsSection: React.FC<AdsSectionProps> = ({ ads }) => {
                     maxHeight: "150px",
                     maxWidth: "100%",
                   }}
-                  src={`${API_BASE_URL}/${ad.imagePath}`}
+                  src={ad.imagePath}
                 />
               </a>
             </Carousel.Item>


### PR DESCRIPTION
**Problem**:
We've already implemented the pre-signed URLs in ticket [R-002e](https://github.com/MyLivingCity/my-living-city/pull/120), so now we want to use these URLs in the client side to display images securely. 

**Areas Changed**: 
Front-end (Client)

**Solution**:
To utilize the new URLs, we changed all current image references to the server's uploads folder `${API_BASE_URL}/${imagePath}` to just `{imagePath}`. This way, the client will only use the new URL as opposed to trying to access static files stored on the server.

**Testing**:
When testing, the respective file must then be uploaded into AWS S3 under the appropriate file name and folder. Then, the rows within `idea`, `advertisement`, and/or `avatar` for the item in question must be manually changed through DBeaver or some other way so that the image name matches the name of the image stored within the AWS S3 bucket. 

