### PR TITLE
Community Dashboard: Fix Available Communities Dropdown Menu and Load It ASAP

### DIFF
--- a/frontend/src/components/content/CommunityDashboardContent.tsx
+++ b/frontend/src/components/content/CommunityDashboardContent.tsx
@@ -1,23 +1,80 @@
 import React from "react";
 import { useState } from "react";
-import {ISegmentAggregateInfo, ISegment} from "./../../lib/types/data/segment.type";
-import { Col, Container, Row, Card, ListGroup, DropdownButton, Dropdown, } from 'react-bootstrap';
+import {
+  ISegmentAggregateInfo,
+  ISegment,
+} from "./../../lib/types/data/segment.type";
+import {
+  Col,
+  Container,
+  Row,
+  Card,
+  ListGroup,
+  DropdownButton,
+  Dropdown,
+} from "react-bootstrap";
 import { capitalizeFirstLetterEachWord } from "./../../lib/utilityFunctions";
 import { IIdeaWithAggregations } from "src/lib/types/data/idea.type";
 import SpecifiedCommunitySection from "../partials/CommunityDashboardContent/SpecifiedCommunitySection";
+import { UseQueryResult } from "react-query";
+import { IFetchError } from "src/lib/types/types";
+import LoadingSpinnerInline from "../ui/LoadingSpinnerInline";
+import ErrorMessage from "../ui/ErrorMessage";
 
 interface CommunityDashboardContentProps {
-    data: ISegmentAggregateInfo,
-    segmentData: ISegment,
-    topIdeas: IIdeaWithAggregations[]
-    segmentIds: any[]
+  data: ISegmentAggregateInfo;
+  segmentData: ISegment;
+  topIdeas: IIdeaWithAggregations[];
+  allUserSegmentsQueryResult: UseQueryResult<any, IFetchError>;
 }
 
-const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({ data, segmentData, topIdeas, segmentIds} : CommunityDashboardContentProps) => {
-
-    // Filter only the segmentIds that have a segType of 'Segment'
-    // Then map it to {id: id, name: name}
-    const segmentIdsFiltered = ([segmentIds]).filter((segId: any) => segId.segType === 'Segment').map((segId: any) => ({id: segId.id, name: segId.name}));
+const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
+  data,
+  segmentData,
+  topIdeas,
+  allUserSegmentsQueryResult,
+}: CommunityDashboardContentProps) => {
+  const {
+    data: segmentIdsObj,
+    isLoading: isSegmentIdsLoading,
+    isError: isSegmentIdsError,
+  } = allUserSegmentsQueryResult;
+  // Get segments as array of objects with id and name, but not super- or sub-segments.
+  const segmentsArray = [];
+  if (!isSegmentIdsLoading && !isSegmentIdsError) {
+    if (
+        segmentIdsObj.homeSegmentId !== undefined &&
+        segmentIdsObj.homeSegmentName !== undefined
+      ) {
+        segmentsArray.push({
+          id: segmentIdsObj.homeSegmentId,
+          name: segmentIdsObj.homeSegmentName,
+        });
+      }
+    
+      if (
+        segmentIdsObj.workSegmentId !== undefined &&
+        segmentIdsObj.workSegmentName !== undefined &&
+        segmentIdsObj.workSegmentName !== segmentIdsObj.homeSegmentName
+      ) {
+        segmentsArray.push({
+          id: segmentIdsObj.workSegmentId,
+          name: segmentIdsObj.workSegmentName,
+        });
+      }
+    
+      if (
+        segmentIdsObj.schoolSegmentId !== undefined &&
+        segmentIdsObj.schoolSegmentName !== undefined &&
+        segmentIdsObj.schoolSegmentName !== segmentIdsObj.homeSegmentName
+      ) {
+        segmentsArray.push({
+          id: segmentIdsObj.schoolSegmentId,
+          name: segmentIdsObj.schoolSegmentName,
+        });
+      }
+  }
+  
 
     const [currCommunityName, setCurrCommunityName] = useState(segmentData.name);
     const [currCommunityPosts, setCurrCommunityPosts] = useState(topIdeas);
@@ -73,118 +130,155 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({ d
 
 
 
-    return (
-        <Container className="user-profile-content w-100">
-            <Row className='mb-4 mt-4 justify-content-left'>
-                <h1 className="pb-2 pt-2 display-6">Community: {capitalizeFirstLetterEachWord(segmentData.name)}</h1>
-                <DropdownButton className='pt-3 ml-2 display-6' title="Available Communities">
-                    {/* Use segmentIdsFiltered to dynamically add segments */}
-                    {segmentIdsFiltered.map((segId: any) => (
-                        <Dropdown.Item href={`/community-dashboard/${segId.id}`}>{capitalizeFirstLetterEachWord(segId.name)}</Dropdown.Item>
-                    ))}
-                </DropdownButton>
+  return (
+    <Container className="user-profile-content w-100">
+      <Row className="mb-4 mt-4 justify-content-left">
+        <h1 className="pb-2 pt-2 display-6">
+          Community: {capitalizeFirstLetterEachWord(segmentData.name)}
+        </h1>
+        {isSegmentIdsLoading && <LoadingSpinnerInline/>}
+        {isSegmentIdsError && <ErrorMessage message="Error loading available communities."/>}
+        {!isSegmentIdsLoading && !isSegmentIdsError && (
+          <DropdownButton
+            className="pt-3 ml-2 display-6"
+            title="Available Communities"
+          >
+            {/* Use segmentIdsFiltered to dynamically add segments */}
+            {segmentsArray.map((segId: any) => (
+              <Dropdown.Item href={`/community-dashboard/${segId.id}`}>
+                {capitalizeFirstLetterEachWord(segId.name)}
+              </Dropdown.Item>
+            ))}
+          </DropdownButton>
+        )}
+      </Row>
+      <Row>
+        <Col>
+          <h2>User Statistics</h2>
+          <Card style={{ width: "25rem" }}>
+            <Row className="justify-content-center mt-3 mb-3">
+              <ListGroup variant="flush" className="">
+                {/* <ListGroup.Item><strong>Total Users</strong></ListGroup.Item> */}
+                <ListGroup.Item>
+                  <h5>Total Users</h5>
+                </ListGroup.Item>
+                <ListGroup.Item>
+                  <strong>Residents</strong>
+                </ListGroup.Item>
+                <ListGroup.Item>
+                  <strong>Students</strong>
+                </ListGroup.Item>
+                <ListGroup.Item>
+                  <strong>Workers</strong>
+                </ListGroup.Item>
+              </ListGroup>
+
+              <ListGroup variant="flush" className="">
+                <ListGroup.Item>
+                  <h5>{data.totalUsers}</h5>
+                </ListGroup.Item>
+                <ListGroup.Item>{data.residents}</ListGroup.Item>
+                <ListGroup.Item>{data.students}</ListGroup.Item>
+                <ListGroup.Item>{data.workers}</ListGroup.Item>
+              </ListGroup>
             </Row>
-            <Row>
-                <Col>
-                    <h2>User Statistics</h2>
-                    <Card style={{width: "25rem"}}>
-                        <Row className='justify-content-center mt-3 mb-3'>
-                            <ListGroup variant='flush' className=''>
-                                {/* <ListGroup.Item><strong>Total Users</strong></ListGroup.Item> */}
-                                <ListGroup.Item><h5>Total Users</h5></ListGroup.Item>
-                                <ListGroup.Item><strong>Residents</strong></ListGroup.Item>
-                                <ListGroup.Item><strong>Students</strong></ListGroup.Item>
-                                <ListGroup.Item><strong>Workers</strong></ListGroup.Item>
-                            </ListGroup>
+          </Card>
+        </Col>
+        <Col>
+          <h2>Post Statistics</h2>
+          <Card style={{ width: "25rem" }}>
+            <Row className="justify-content-center mt-3 mb-3">
+              <ListGroup variant="flush" className="">
+                <ListGroup.Item>
+                  <h5>Total Posts</h5>
+                </ListGroup.Item>
+                <ListGroup.Item>
+                  <strong>Ideas</strong>
+                </ListGroup.Item>
+                <ListGroup.Item>
+                  <strong>Proposal</strong>
+                </ListGroup.Item>
+                <ListGroup.Item>
+                  <strong>Projects</strong>
+                </ListGroup.Item>
+              </ListGroup>
 
-                            <ListGroup variant='flush' className=''>
-                                <ListGroup.Item><h5>{ data.totalUsers }</h5></ListGroup.Item>
-                                <ListGroup.Item>{ data.residents }</ListGroup.Item>
-                                <ListGroup.Item>{ data.students }</ListGroup.Item>
-                                <ListGroup.Item>{ data.workers }</ListGroup.Item>
-                            </ListGroup>
-                        </Row>
-                    </Card>
-                </Col>
-                <Col>
-                <h2>Post Statistics</h2>
-                    <Card style={{width: "25rem"}}>
-                        <Row className='justify-content-center mt-3 mb-3'>
-                            <ListGroup variant='flush' className=''>
-                                <ListGroup.Item><h5>Total Posts</h5></ListGroup.Item>
-                                <ListGroup.Item><strong>Ideas</strong></ListGroup.Item>
-                                <ListGroup.Item><strong>Proposal</strong></ListGroup.Item>
-                                <ListGroup.Item><strong>Projects</strong></ListGroup.Item>
-                            </ListGroup>
-
-                            <ListGroup variant='flush' className=''>
-                                <ListGroup.Item><h5>{ data.ideas + data.proposals + data.projects }</h5></ListGroup.Item>
-                                <ListGroup.Item>{ data.ideas }</ListGroup.Item>
-                                <ListGroup.Item>{ data.proposals }</ListGroup.Item>
-                                <ListGroup.Item>{ data.projects }</ListGroup.Item>
-                            </ListGroup>
-
-                        </Row>
-                    </Card>
-                </Col>
+              <ListGroup variant="flush" className="">
+                <ListGroup.Item>
+                  <h5>{data.ideas + data.proposals + data.projects}</h5>
+                </ListGroup.Item>
+                <ListGroup.Item>{data.ideas}</ListGroup.Item>
+                <ListGroup.Item>{data.proposals}</ListGroup.Item>
+                <ListGroup.Item>{data.projects}</ListGroup.Item>
+              </ListGroup>
             </Row>
+          </Card>
+        </Col>
+      </Row>
 
-            <Row style={{marginTop: "3rem"}}>
-                <Col>
-                    <Card style={{ width: '18rem' }}>
-                        <Card.Header><h4>Region</h4></Card.Header>
-                        <ListGroup 
-                        variant="flush"
-                        id="region-list"
-                        >
-                            <ListGroup.Item 
-                            action
-                            onClick={() => handleCommunityChange(data.superSegmentName, "SuperSegment")}
-                            >
-                                {capitalizeFirstLetterEachWord(data.superSegmentName)}
-                            </ListGroup.Item>
-                        </ListGroup>
-                    </Card>
-                </Col>
-                <Col>
-                    <Card style={{ width: '18rem' }}>
-                        <Card.Header><h4>Municipality</h4></Card.Header>
-                        <ListGroup 
-                        variant="flush" 
-                        defaultActiveKey="#link1"
-                        id="municipality-list"
-                        >
-                            <ListGroup.Item 
-                            action 
-                            active
-                            onClick={() => handleCommunityChange(segmentData.name, "Segment")}
-                            >
-                                {capitalizeFirstLetterEachWord(segmentData.name)}
-                            </ListGroup.Item>
-                        </ListGroup>
-                    </Card>
-                </Col>
-                <Col>
-                    <Card style={{ width: '18rem' }}>
-                        <Card.Header><h4>Neighbourhood</h4></Card.Header>
-                        <ListGroup 
-                        variant="flush"
-                        id="neighbourhood-list"
-                        >
-                            {data.subSegments.length > 0 ? data.subSegments.map((subSeg) => 
-                            <ListGroup.Item 
-                            action
-                            onClick={() => handleCommunityChange(subSeg, "SubSegment")}
-                            >
-                                {capitalizeFirstLetterEachWord(subSeg)}
-                            </ListGroup.Item>
-                            ) :
-                            <ListGroup.Item>No subSegments</ListGroup.Item>}
-                        </ListGroup>
-                    </Card>
-                </Col>
+      <Row style={{ marginTop: "3rem" }}>
+        <Col>
+          <Card style={{ width: "18rem" }}>
+            <Card.Header>
+              <h4>Region</h4>
+            </Card.Header>
+            <ListGroup variant="flush" id="region-list">
+              <ListGroup.Item
+                action
+                onClick={() =>
+                  handleCommunityChange(data.superSegmentName, "SuperSegment")
+                }
+              >
+                {capitalizeFirstLetterEachWord(data.superSegmentName)}
+              </ListGroup.Item>
+            </ListGroup>
+          </Card>
+        </Col>
+        <Col>
+          <Card style={{ width: "18rem" }}>
+            <Card.Header>
+              <h4>Municipality</h4>
+            </Card.Header>
+            <ListGroup
+              variant="flush"
+              defaultActiveKey="#link1"
+              id="municipality-list"
+            >
+              <ListGroup.Item
+                action
+                active
+                onClick={() =>
+                  handleCommunityChange(segmentData.name, "Segment")
+                }
+              >
+                {capitalizeFirstLetterEachWord(segmentData.name)}
+              </ListGroup.Item>
+            </ListGroup>
+          </Card>
+        </Col>
+        <Col>
+          <Card style={{ width: "18rem" }}>
+            <Card.Header>
+              <h4>Neighbourhood</h4>
+            </Card.Header>
+            <ListGroup variant="flush" id="neighbourhood-list">
+              {data.subSegments.length > 0 ? (
+                data.subSegments.map((subSeg) => (
+                  <ListGroup.Item
+                    action
+                    onClick={() => handleCommunityChange(subSeg, "SubSegment")}
+                  >
+                    {capitalizeFirstLetterEachWord(subSeg)}
+                  </ListGroup.Item>
+                ))
+              ) : (
+                <ListGroup.Item>No subSegments</ListGroup.Item>
+              )}
+            </ListGroup>
+          </Card>
+        </Col>
 
-                {/* TODO: The community partner is not implemented yet
+        {/* TODO: The community partner is not implemented yet
                 <Col>
                     <Card style={{ width: '18rem' }}>
                         <Card.Header><h4>Community Partners</h4></Card.Header>
@@ -194,12 +288,17 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({ d
                     </Card>
                 </Col>
                 */}
-            </Row>
-            <Row style={{marginTop: "3rem"}}>
-            <SpecifiedCommunitySection sectionTitle={currCommunityName} topIdeas={currCommunityPosts} isDashboard={false} showCustomFilter={false}/>
-            </Row>
-        </Container>
-    )
-}
+      </Row>
+      <Row style={{ marginTop: "3rem" }}>
+        <SpecifiedCommunitySection
+          sectionTitle={currCommunityName}
+          topIdeas={currCommunityPosts}
+          isDashboard={false}
+          showCustomFilter={false}
+        />
+      </Row>
+    </Container>
+  );
+};
 
 export default CommunityDashboardContent;

--- a/frontend/src/components/content/CommunityDashboardContent.tsx
+++ b/frontend/src/components/content/CommunityDashboardContent.tsx
@@ -8,14 +8,13 @@ import { IUser } from "src/lib/types/data/user.type";
 import SpecifiedCommunitySection from "../partials/CommunityDashboardContent/SpecifiedCommunitySection";
 
 interface CommunityDashboardContentProps {
-    userData: IUser
     data: ISegmentAggregateInfo,
     segmenData: ISegment,
     topIdeas: IIdeaWithAggregations[]
     segmentIds: any[]
 }
 
-const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({userData, data, segmenData, topIdeas, segmentIds} : CommunityDashboardContentProps) => {
+const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({ data, segmenData, topIdeas, segmentIds} : CommunityDashboardContentProps) => {
 
     // Filter only the segmentIds that have a segType of 'Segment'
     // Then map it to {id: id, name: name}

--- a/frontend/src/components/content/CommunityDashboardContent.tsx
+++ b/frontend/src/components/content/CommunityDashboardContent.tsx
@@ -4,23 +4,22 @@ import {ISegmentAggregateInfo, ISegment} from "./../../lib/types/data/segment.ty
 import { Col, Container, Row, Card, ListGroup, DropdownButton, Dropdown, } from 'react-bootstrap';
 import { capitalizeFirstLetterEachWord } from "./../../lib/utilityFunctions";
 import { IIdeaWithAggregations } from "src/lib/types/data/idea.type";
-import { IUser } from "src/lib/types/data/user.type";
 import SpecifiedCommunitySection from "../partials/CommunityDashboardContent/SpecifiedCommunitySection";
 
 interface CommunityDashboardContentProps {
     data: ISegmentAggregateInfo,
-    segmenData: ISegment,
+    segmentData: ISegment,
     topIdeas: IIdeaWithAggregations[]
     segmentIds: any[]
 }
 
-const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({ data, segmenData, topIdeas, segmentIds} : CommunityDashboardContentProps) => {
+const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({ data, segmentData, topIdeas, segmentIds} : CommunityDashboardContentProps) => {
 
     // Filter only the segmentIds that have a segType of 'Segment'
     // Then map it to {id: id, name: name}
     const segmentIdsFiltered = ([segmentIds]).filter((segId: any) => segId.segType === 'Segment').map((segId: any) => ({id: segId.id, name: segId.name}));
 
-    const [currCommunityName, setCurrCommunityName] = useState(segmenData.name);
+    const [currCommunityName, setCurrCommunityName] = useState(segmentData.name);
     const [currCommunityPosts, setCurrCommunityPosts] = useState(topIdeas);
 
     const handleCommunityChange = (communityName: string, type: string) => {
@@ -77,7 +76,7 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({ d
     return (
         <Container className="user-profile-content w-100">
             <Row className='mb-4 mt-4 justify-content-left'>
-                <h1 className="pb-2 pt-2 display-6">Community: {capitalizeFirstLetterEachWord(segmenData.name)}</h1>
+                <h1 className="pb-2 pt-2 display-6">Community: {capitalizeFirstLetterEachWord(segmentData.name)}</h1>
                 <DropdownButton className='pt-3 ml-2 display-6' title="Available Communities">
                     {/* Use segmentIdsFiltered to dynamically add segments */}
                     {segmentIdsFiltered.map((segId: any) => (
@@ -158,9 +157,9 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({ d
                             <ListGroup.Item 
                             action 
                             active
-                            onClick={() => handleCommunityChange(segmenData.name, "Segment")}
+                            onClick={() => handleCommunityChange(segmentData.name, "Segment")}
                             >
-                                {capitalizeFirstLetterEachWord(segmenData.name)}
+                                {capitalizeFirstLetterEachWord(segmentData.name)}
                             </ListGroup.Item>
                         </ListGroup>
                     </Card>

--- a/frontend/src/components/content/CommunityDashboardContent.tsx
+++ b/frontend/src/components/content/CommunityDashboardContent.tsx
@@ -48,29 +48,30 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
       ) {
         segmentsArray.push({
           id: segmentIdsObj.homeSegmentId,
-          name: segmentIdsObj.homeSegmentName,
+          name: "🏠" + segmentIdsObj.homeSegmentName,
         });
       }
     
       if (
         segmentIdsObj.workSegmentId !== undefined &&
         segmentIdsObj.workSegmentName !== undefined &&
-        segmentIdsObj.workSegmentName !== segmentIdsObj.homeSegmentName
+        segmentIdsObj.workSegmentId !== segmentIdsObj.homeSegmentId
       ) {
         segmentsArray.push({
           id: segmentIdsObj.workSegmentId,
-          name: segmentIdsObj.workSegmentName,
+          name: "🏢" + segmentIdsObj.workSegmentName,
         });
       }
     
       if (
         segmentIdsObj.schoolSegmentId !== undefined &&
         segmentIdsObj.schoolSegmentName !== undefined &&
-        segmentIdsObj.schoolSegmentName !== segmentIdsObj.homeSegmentName
+        segmentIdsObj.schoolSegmentId !== segmentIdsObj.homeSegmentId &&
+        segmentIdsObj.schoolSegmentId !== segmentIdsObj.workSegmentId
       ) {
         segmentsArray.push({
           id: segmentIdsObj.schoolSegmentId,
-          name: segmentIdsObj.schoolSegmentName,
+          name: "🏫" + segmentIdsObj.schoolSegmentName,
         });
       }
   }

--- a/frontend/src/components/content/CommunityDashboardContent.tsx
+++ b/frontend/src/components/content/CommunityDashboardContent.tsx
@@ -20,6 +20,7 @@ import { UseQueryResult } from "react-query";
 import { IFetchError } from "src/lib/types/types";
 import LoadingSpinnerInline from "../ui/LoadingSpinnerInline";
 import ErrorMessage from "../ui/ErrorMessage";
+import { useParams } from "react-router-dom";
 
 interface CommunityDashboardContentProps {
   data: ISegmentAggregateInfo;
@@ -28,12 +29,19 @@ interface CommunityDashboardContentProps {
   allUserSegmentsQueryResult: UseQueryResult<any, IFetchError>;
 }
 
+interface RouteParams {
+    segId: string;
+}
+
 const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
   data,
   segmentData,
   topIdeas,
   allUserSegmentsQueryResult,
 }: CommunityDashboardContentProps) => {
+    const {segId} = useParams<RouteParams>();
+    const currentSegmentId = parseInt(segId)
+   
   const {
     data: segmentIdsObj,
     isLoading: isSegmentIdsLoading,
@@ -48,7 +56,7 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
       ) {
         segmentsArray.push({
           id: segmentIdsObj.homeSegmentId,
-          name: "🏠" + segmentIdsObj.homeSegmentName,
+          name: segmentIdsObj.homeSegmentName + " 🏠",
         });
       }
     
@@ -59,7 +67,7 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
       ) {
         segmentsArray.push({
           id: segmentIdsObj.workSegmentId,
-          name: "🏢" + segmentIdsObj.workSegmentName,
+          name: segmentIdsObj.workSegmentName + " 🏢",
         });
       }
     
@@ -71,12 +79,11 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
       ) {
         segmentsArray.push({
           id: segmentIdsObj.schoolSegmentId,
-          name: "🏫" + segmentIdsObj.schoolSegmentName,
+          name: segmentIdsObj.schoolSegmentName + " 🏫",
         });
       }
   }
   
-
     const [currCommunityName, setCurrCommunityName] = useState(segmentData.name);
     const [currCommunityPosts, setCurrCommunityPosts] = useState(topIdeas);
 
@@ -135,19 +142,19 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
     <Container className="user-profile-content w-100">
       <Row className="mb-4 mt-4 justify-content-left">
         <h1 className="pb-2 pt-2 display-6">
-          Community: {capitalizeFirstLetterEachWord(segmentData.name)}
+          Community:
         </h1>
         {isSegmentIdsLoading && <LoadingSpinnerInline/>}
         {isSegmentIdsError && <ErrorMessage message="Error loading available communities."/>}
         {!isSegmentIdsLoading && !isSegmentIdsError && (
           <DropdownButton
             className="pt-3 ml-2 display-6"
-            title="Available Communities"
+            title={capitalizeFirstLetterEachWord(segmentData.name)}
           >
             {/* Use segmentIdsFiltered to dynamically add segments */}
-            {segmentsArray.map((segId: any) => (
-              <Dropdown.Item href={`/community-dashboard/${segId.id}`}>
-                {capitalizeFirstLetterEachWord(segId.name)}
+            {segmentsArray.map((segment: any) => (
+              <Dropdown.Item className="text-center" href={`/community-dashboard/${segment.id}`} disabled={segment.id === currentSegmentId}>
+                {capitalizeFirstLetterEachWord(segment.name)}
               </Dropdown.Item>
             ))}
           </DropdownButton>

--- a/frontend/src/components/content/CommunityDashboardContent.tsx
+++ b/frontend/src/components/content/CommunityDashboardContent.tsx
@@ -141,19 +141,23 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
   return (
     <Container className="user-profile-content w-100">
       <Row className="mb-4 mt-4 justify-content-left">
-        <h1 className="pb-2 pt-2 display-6">
-          Community:
-        </h1>
-        {isSegmentIdsLoading && <LoadingSpinnerInline/>}
-        {isSegmentIdsError && <ErrorMessage message="Error loading available communities."/>}
+        <h1 className="pb-2 pt-2 display-6">Community:</h1>
+        {isSegmentIdsLoading && <LoadingSpinnerInline />}
+        {isSegmentIdsError && (
+          <ErrorMessage message="Error loading available communities." />
+        )}
         {!isSegmentIdsLoading && !isSegmentIdsError && (
           <DropdownButton
-            className="pt-3 ml-2 display-6"
+            className="pt-2 ml-2 display-6 custom-dropdown-button"
             title={capitalizeFirstLetterEachWord(segmentData.name)}
           >
-            {/* Use segmentIdsFiltered to dynamically add segments */}
             {segmentsArray.map((segment: any) => (
-              <Dropdown.Item className="text-center" href={`/community-dashboard/${segment.id}`} disabled={segment.id === currentSegmentId}>
+              <Dropdown.Item
+                key={segment.id}
+                className="text-center"
+                href={`/community-dashboard/${segment.id}`}
+                disabled={segment.id === currentSegmentId}
+              >
                 {capitalizeFirstLetterEachWord(segment.name)}
               </Dropdown.Item>
             ))}

--- a/frontend/src/pages/CommunityDashboardPage.tsx
+++ b/frontend/src/pages/CommunityDashboardPage.tsx
@@ -22,11 +22,6 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     const { user, token } = useContext(UserProfileContext);
 
     const {
-        data: userSegments,
-        isLoading: isUserSegmentsLoading,
-        isError: isUserSegmentsError
-    } = useAllUserSegments(token, user?.id || null);
-    const {
       data: segmentAggregateData,
       isLoading: isAggregateLoading,
       isError: isAggregateError,
@@ -41,19 +36,11 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
       isLoading: iIsLoading,
       isError: iIsError,
     } = useIdeasHomepage();
+    const allUserSegmentsQueryResult = useAllUserSegments(token, user?.id || null);
 
-    // if segId == 0 then use userSegments to set segId to the home segment
-    if (parseInt(segId, 10) === 0 && userSegments) {
-      let home_segment_id = 0;
-      if (Array.isArray(userSegments)) {
-        home_segment_id = userSegments.filter(
-          (seg: any) => seg.segType === "Segment" && seg.userType === "Resident"
-        )[0].homeSegmentId;
-      } else {
-        home_segment_id = userSegments.homeSegmentId;
-      }
-
-      props.history.push(`/community-dashboard/${home_segment_id}`);
+    // if segId == 0 then use segmentIds to set segId to the home segment
+    if (parseInt(segId) === 0 && allUserSegmentsQueryResult.data?.homeSegmentId) {
+      props.history.push(`/community-dashboard/${allUserSegmentsQueryResult.data.homeSegmentId}`);
       window.location.reload();
     }
 
@@ -66,7 +53,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     }
 
 
-    if (isAggregateError || isSegmentInfoError || iIsError || isUserSegmentsError) {
+    if (isAggregateError || isSegmentInfoError || iIsError) {
         return (
           <div className="wrapper">
             <p>
@@ -76,7 +63,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
         );
     }
 
-    if (isAggregateLoading || isSegmentInfoLoading || iIsLoading || isUserSegmentsLoading) {
+    if (isAggregateLoading || isSegmentInfoLoading || iIsLoading) {
         return (
           <div className="wrapper">
             <LoadingSpinner />
@@ -99,7 +86,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     return (
         <>
             <div className="wrapper">
-                <CommunityDashboardContent topIdeas={filteredTopIdeas()} data={segmentAggregateData!} segmentData={segmentInfoData!} segmentIds={userSegments} />
+                <CommunityDashboardContent topIdeas={filteredTopIdeas()} data={segmentAggregateData!} segmentData={segmentInfoData!} allUserSegmentsQueryResult={allUserSegmentsQueryResult} />
             </div>
         </>
     );

--- a/frontend/src/pages/CommunityDashboardPage.tsx
+++ b/frontend/src/pages/CommunityDashboardPage.tsx
@@ -4,7 +4,6 @@ import LoadingSpinner from "../components/ui/LoadingSpinner";
 import { useSegmentInfoAggregate, useSingleSegmentBySegmentId } from "./../hooks/segmentHooks";
 import { useIdeasHomepage } from "src/hooks/ideaHooks";
 import { IIdeaWithAggregations } from "src/lib/types/data/idea.type";
-import { useUserWithJwtVerbose } from "src/hooks/userHooks";
 import { useContext } from "react";
 import { UserProfileContext } from "src/contexts/UserProfile.Context";
 import { useAllUserSegments } from "src/hooks/userSegmentHooks";
@@ -20,11 +19,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
         },
     } = props;
 
-    const { logout, user, token } = useContext(UserProfileContext);
-    const { data: userData } = useUserWithJwtVerbose({
-      jwtAuthToken: token!,
-      shouldTrigger: token != null,
-    });
+    const { user, token } = useContext(UserProfileContext);
 
     const {
         data: userSegments,
@@ -42,28 +37,27 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
         }
 
         props.history.push(`/community-dashboard/${home_segment_id}`);
-        // segId = home_segment_id.toString();
         window.location.reload();
     }
 
 
-    const {data: segmentAggregatData,
-            error, 
-            isLoading: isAggregateLoading, 
-            isError: isAggregateError
-        } = useSegmentInfoAggregate(parseInt(segId));
-    const {data: segmentInfoData,
-        error: segmentInfoError,
-        isLoading: isSegmentInfoLoading,
-        isError: isSegmentInfoError,
-        } = useSingleSegmentBySegmentId(parseInt(segId));
+    const {
+      data: segmentAggregatData,
+      isLoading: isAggregateLoading,
+      isError: isAggregateError,
+    } = useSegmentInfoAggregate(parseInt(segId));
+    const {
+      data: segmentInfoData,
+      isLoading: isSegmentInfoLoading,
+      isError: isSegmentInfoError,
+    } = useSingleSegmentBySegmentId(parseInt(segId));
 
     const {
-        data: iData,
-        error: iError,
-        isLoading: iLoading,
-        isError: iIsError,
-        } = useIdeasHomepage();
+      data: iData,
+      error: iError,
+      isLoading: iLoading,
+      isError: iIsError,
+    } = useIdeasHomepage();
 
     if (segId === "0") {
         return (
@@ -84,7 +78,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
         );
     }
 
-    if (isAggregateLoading || isSegmentInfoLoading || iLoading || userData === null || userData === undefined || isUserSegmentsLoading) {
+    if (isAggregateLoading || isSegmentInfoLoading || iLoading || isUserSegmentsLoading) {
         return (
           <div className="wrapper">
             <LoadingSpinner />
@@ -107,7 +101,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     return (
         <>
             <div className="wrapper">
-                <CommunityDashboardContent userData ={userData!} topIdeas={filteredTopIdeas()} data={segmentAggregatData!} segmenData={segmentInfoData!} segmentIds={userSegments} />
+                <CommunityDashboardContent topIdeas={filteredTopIdeas()} data={segmentAggregatData!} segmenData={segmentInfoData!} segmentIds={userSegments} />
             </div>
         </>
     );

--- a/frontend/src/pages/CommunityDashboardPage.tsx
+++ b/frontend/src/pages/CommunityDashboardPage.tsx
@@ -26,21 +26,6 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
         isLoading: isUserSegmentsLoading,
         isError: isUserSegmentsError
     } = useAllUserSegments(token, user?.id || null);
-
-    // if segId == 0 then use userSegments to set segId to the home segment
-    if (parseInt(segId, 10) === 0 && userSegments) {
-        let home_segment_id = 0
-        if (Array.isArray(userSegments)) {
-            home_segment_id = (userSegments).filter((seg: any) => seg.segType === "Segment" && seg.userType === "Resident")[0].homeSegmentId;
-        } else {
-            home_segment_id = userSegments.homeSegmentId
-        }
-
-        props.history.push(`/community-dashboard/${home_segment_id}`);
-        window.location.reload();
-    }
-
-
     const {
       data: segmentAggregateData,
       isLoading: isAggregateLoading,
@@ -51,12 +36,26 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
       isLoading: isSegmentInfoLoading,
       isError: isSegmentInfoError,
     } = useSingleSegmentBySegmentId(parseInt(segId));
-
     const {
       data: iData,
       isLoading: iIsLoading,
       isError: iIsError,
     } = useIdeasHomepage();
+
+    // if segId == 0 then use userSegments to set segId to the home segment
+    if (parseInt(segId, 10) === 0 && userSegments) {
+      let home_segment_id = 0;
+      if (Array.isArray(userSegments)) {
+        home_segment_id = userSegments.filter(
+          (seg: any) => seg.segType === "Segment" && seg.userType === "Resident"
+        )[0].homeSegmentId;
+      } else {
+        home_segment_id = userSegments.homeSegmentId;
+      }
+
+      props.history.push(`/community-dashboard/${home_segment_id}`);
+      window.location.reload();
+    }
 
     if (segId === "0") {
         return (

--- a/frontend/src/pages/CommunityDashboardPage.tsx
+++ b/frontend/src/pages/CommunityDashboardPage.tsx
@@ -42,7 +42,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
 
 
     const {
-      data: segmentAggregatData,
+      data: segmentAggregateData,
       isLoading: isAggregateLoading,
       isError: isAggregateError,
     } = useSegmentInfoAggregate(parseInt(segId));
@@ -54,8 +54,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
 
     const {
       data: iData,
-      error: iError,
-      isLoading: iLoading,
+      isLoading: iIsLoading,
       isError: iIsError,
     } = useIdeasHomepage();
 
@@ -68,7 +67,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     }
 
 
-    if (isAggregateError || isSegmentInfoError || iError || isUserSegmentsError) {
+    if (isAggregateError || isSegmentInfoError || iIsError || isUserSegmentsError) {
         return (
           <div className="wrapper">
             <p>
@@ -78,7 +77,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
         );
     }
 
-    if (isAggregateLoading || isSegmentInfoLoading || iLoading || isUserSegmentsLoading) {
+    if (isAggregateLoading || isSegmentInfoLoading || iIsLoading || isUserSegmentsLoading) {
         return (
           <div className="wrapper">
             <LoadingSpinner />
@@ -101,7 +100,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     return (
         <>
             <div className="wrapper">
-                <CommunityDashboardContent topIdeas={filteredTopIdeas()} data={segmentAggregatData!} segmenData={segmentInfoData!} segmentIds={userSegments} />
+                <CommunityDashboardContent topIdeas={filteredTopIdeas()} data={segmentAggregateData!} segmentData={segmentInfoData!} segmentIds={userSegments} />
             </div>
         </>
     );

--- a/frontend/src/pages/CommunityDashboardPage.tsx
+++ b/frontend/src/pages/CommunityDashboardPage.tsx
@@ -37,7 +37,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
       isError: iIsError,
     } = useIdeasHomepage();
     const allUserSegmentsQueryResult = useAllUserSegments(token, user?.id || null);
-
+    // const segmentInfoAggregateQueryResult = useSegmentInfoAggregate(parseInt(segId));
     // if segId == 0 then use segmentIds to set segId to the home segment
     if (parseInt(segId) === 0 && allUserSegmentsQueryResult.data?.homeSegmentId) {
       props.history.push(`/community-dashboard/${allUserSegmentsQueryResult.data.homeSegmentId}`);
@@ -84,11 +84,17 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     }
 
     return (
-        <>
-            <div className="wrapper">
-                <CommunityDashboardContent topIdeas={filteredTopIdeas()} data={segmentAggregateData!} segmentData={segmentInfoData!} allUserSegmentsQueryResult={allUserSegmentsQueryResult} />
-            </div>
-        </>
+      <>
+        <div className="wrapper">
+          <CommunityDashboardContent
+            topIdeas={filteredTopIdeas()}
+            data={segmentAggregateData!}
+            segmentData={segmentInfoData!}
+            allUserSegmentsQueryResult={allUserSegmentsQueryResult}
+            // segmentInfoAggregateQueryResult={segmentInfoAggregateQueryResult}
+          />
+        </div>
+      </>
     );
 }
 

--- a/frontend/src/scss/ui/_other.scss
+++ b/frontend/src/scss/ui/_other.scss
@@ -28,3 +28,9 @@
     line-height: 1.1 !important;
      }
 }
+
+.custom-dropdown-button .dropdown-toggle {
+  font-size: 1.5rem;
+  line-height: '1'; 
+  height: 'auto';
+}


### PR DESCRIPTION
This pull request is part of a series to load components in the Community Dashboard page as soon as data is available.

**Changes**:
- Moved loading spinner and error message related to loading user segments in `useAllUserSegments` hook into the `CommunityDashboardContent` component
- Discovered the data is an object with relevant key values and not an array, removed Array prototype functions and instead singled out relevant properties for the "Available Communities" dropdown menu
- Discussed the current visuals of the dropdown menu with Nic, decided to replace the static text showing the current community name with the button itself showing the name

The old dropdown menu was not working:
<img width="593" alt="image" src="https://github.com/MyLivingCity/my-living-city/assets/112919426/abf790a1-84bb-45e9-a7fb-31d923bd6a22">

New version with community name in the button instead of as text: 
<img width="456" alt="image" src="https://github.com/MyLivingCity/my-living-city/assets/112919426/95bad409-f27a-4439-aa80-bd2aa4700455">
