### PR TITLE
Community Dashboard: Load remaining components in page as soon as they receive data

### DIFF
--- a/frontend/src/components/content/CommunityDashboardContent.tsx
+++ b/frontend/src/components/content/CommunityDashboardContent.tsx
@@ -23,10 +23,10 @@ import ErrorMessage from "../ui/ErrorMessage";
 import { useParams } from "react-router-dom";
 
 interface CommunityDashboardContentProps {
-  data: ISegmentAggregateInfo;
   segmentData: ISegment;
   topIdeas: IIdeaWithAggregations[];
   allUserSegmentsQueryResult: UseQueryResult<any, IFetchError>;
+  segmentInfoAggregateQueryResult: UseQueryResult<ISegmentAggregateInfo, IFetchError>
 }
 
 interface RouteParams {
@@ -34,10 +34,10 @@ interface RouteParams {
 }
 
 const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
-  data,
   segmentData,
   topIdeas,
   allUserSegmentsQueryResult,
+  segmentInfoAggregateQueryResult
 }: CommunityDashboardContentProps) => {
     const {segId} = useParams<RouteParams>();
     const currentSegmentId = parseInt(segId)
@@ -47,6 +47,11 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
     isLoading: isSegmentIdsLoading,
     isError: isSegmentIdsError,
   } = allUserSegmentsQueryResult;
+  const {
+    data: segmentInfoAggregateData,
+    isLoading: isSegmentInfoAggregateLoading,
+    isError: isSegmentInfoAggregateError,
+  } = segmentInfoAggregateQueryResult
   // Get segments as array of objects with id and name, but not super- or sub-segments.
   const segmentsArray = [];
   if (!isSegmentIdsLoading && !isSegmentIdsError) {
@@ -168,62 +173,89 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
         <Col>
           <h2>User Statistics</h2>
           <Card style={{ width: "25rem" }}>
-            <Row className="justify-content-center mt-3 mb-3">
-              <ListGroup variant="flush" className="">
-                {/* <ListGroup.Item><strong>Total Users</strong></ListGroup.Item> */}
-                <ListGroup.Item>
-                  <h5>Total Users</h5>
-                </ListGroup.Item>
-                <ListGroup.Item>
-                  <strong>Residents</strong>
-                </ListGroup.Item>
-                <ListGroup.Item>
-                  <strong>Students</strong>
-                </ListGroup.Item>
-                <ListGroup.Item>
-                  <strong>Workers</strong>
-                </ListGroup.Item>
-              </ListGroup>
+            {isSegmentInfoAggregateLoading && <LoadingSpinnerInline />}
+            {!isSegmentInfoAggregateLoading && isSegmentInfoAggregateError && (
+              <ErrorMessage message="There was an error loading user statistics." />
+            )}
+            {!isSegmentInfoAggregateLoading && !isSegmentInfoAggregateError && (
+              <Row className="justify-content-center mt-3 mb-3">
+                <ListGroup variant="flush" className="">
+                  <ListGroup.Item>
+                    <h5>Total Users</h5>
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    <strong>Residents</strong>
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    <strong>Students</strong>
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    <strong>Workers</strong>
+                  </ListGroup.Item>
+                </ListGroup>
 
-              <ListGroup variant="flush" className="">
-                <ListGroup.Item>
-                  <h5>{data.totalUsers}</h5>
-                </ListGroup.Item>
-                <ListGroup.Item>{data.residents}</ListGroup.Item>
-                <ListGroup.Item>{data.students}</ListGroup.Item>
-                <ListGroup.Item>{data.workers}</ListGroup.Item>
-              </ListGroup>
-            </Row>
+                <ListGroup variant="flush" className="">
+                  <ListGroup.Item>
+                    <h5>{segmentInfoAggregateData!.totalUsers}</h5>
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    {segmentInfoAggregateData!.residents}
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    {segmentInfoAggregateData!.students}
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    {segmentInfoAggregateData!.workers}
+                  </ListGroup.Item>
+                </ListGroup>
+              </Row>
+            )}
           </Card>
         </Col>
         <Col>
           <h2>Post Statistics</h2>
           <Card style={{ width: "25rem" }}>
-            <Row className="justify-content-center mt-3 mb-3">
-              <ListGroup variant="flush" className="">
-                <ListGroup.Item>
-                  <h5>Total Posts</h5>
-                </ListGroup.Item>
-                <ListGroup.Item>
-                  <strong>Ideas</strong>
-                </ListGroup.Item>
-                <ListGroup.Item>
-                  <strong>Proposal</strong>
-                </ListGroup.Item>
-                <ListGroup.Item>
-                  <strong>Projects</strong>
-                </ListGroup.Item>
-              </ListGroup>
+            {isSegmentInfoAggregateLoading && <LoadingSpinnerInline />}
+            {!isSegmentInfoAggregateLoading && isSegmentInfoAggregateError && (
+              <ErrorMessage message="There was an error loading user statistics." />
+            )}
+            {!isSegmentInfoAggregateLoading && !isSegmentInfoAggregateError && (
+              <Row className="justify-content-center mt-3 mb-3">
+                <ListGroup variant="flush" className="">
+                  <ListGroup.Item>
+                    <h5>Total Posts</h5>
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    <strong>Ideas</strong>
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    <strong>Proposal</strong>
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    <strong>Projects</strong>
+                  </ListGroup.Item>
+                </ListGroup>
 
-              <ListGroup variant="flush" className="">
-                <ListGroup.Item>
-                  <h5>{data.ideas + data.proposals + data.projects}</h5>
-                </ListGroup.Item>
-                <ListGroup.Item>{data.ideas}</ListGroup.Item>
-                <ListGroup.Item>{data.proposals}</ListGroup.Item>
-                <ListGroup.Item>{data.projects}</ListGroup.Item>
-              </ListGroup>
-            </Row>
+                <ListGroup variant="flush" className="">
+                  <ListGroup.Item>
+                    <h5>
+                      {segmentInfoAggregateData!.ideas +
+                        segmentInfoAggregateData!.proposals +
+                        segmentInfoAggregateData!.projects}
+                    </h5>
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    {segmentInfoAggregateData!.ideas}
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    {segmentInfoAggregateData!.proposals}
+                  </ListGroup.Item>
+                  <ListGroup.Item>
+                    {segmentInfoAggregateData!.projects}
+                  </ListGroup.Item>
+                </ListGroup>
+              </Row>
+            )}
           </Card>
         </Col>
       </Row>
@@ -235,14 +267,27 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
               <h4>Region</h4>
             </Card.Header>
             <ListGroup variant="flush" id="region-list">
-              <ListGroup.Item
-                action
-                onClick={() =>
-                  handleCommunityChange(data.superSegmentName, "SuperSegment")
-                }
-              >
-                {capitalizeFirstLetterEachWord(data.superSegmentName)}
-              </ListGroup.Item>
+              {isSegmentInfoAggregateLoading && <LoadingSpinnerInline />}
+              {!isSegmentInfoAggregateLoading &&
+                isSegmentInfoAggregateError && (
+                  <ErrorMessage message="Unable to load region." />
+                )}
+              {!isSegmentInfoAggregateLoading &&
+                !isSegmentInfoAggregateError && (
+                  <ListGroup.Item
+                    action
+                    onClick={() =>
+                      handleCommunityChange(
+                        segmentInfoAggregateData!.superSegmentName,
+                        "SuperSegment"
+                      )
+                    }
+                  >
+                    {capitalizeFirstLetterEachWord(
+                      segmentInfoAggregateData!.superSegmentName
+                    )}
+                  </ListGroup.Item>
+                )}
             </ListGroup>
           </Card>
         </Col>
@@ -256,6 +301,13 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
               defaultActiveKey="#link1"
               id="municipality-list"
             >
+              {isSegmentInfoAggregateLoading && <LoadingSpinnerInline />}
+              {!isSegmentInfoAggregateLoading &&
+                isSegmentInfoAggregateError && (
+                  <ErrorMessage message="Unable to load municipality." />
+                )}
+              {!isSegmentInfoAggregateLoading &&
+                !isSegmentInfoAggregateError && (
               <ListGroup.Item
                 action
                 active
@@ -264,7 +316,7 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
                 }
               >
                 {capitalizeFirstLetterEachWord(segmentData.name)}
-              </ListGroup.Item>
+              </ListGroup.Item>)}
             </ListGroup>
           </Card>
         </Col>
@@ -274,8 +326,15 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
               <h4>Neighbourhood</h4>
             </Card.Header>
             <ListGroup variant="flush" id="neighbourhood-list">
-              {data.subSegments.length > 0 ? (
-                data.subSegments.map((subSeg) => (
+            {isSegmentInfoAggregateLoading && <LoadingSpinnerInline />}
+              {!isSegmentInfoAggregateLoading &&
+                isSegmentInfoAggregateError && (
+                  <ErrorMessage message="Unable to load region." />
+                )}
+              {!isSegmentInfoAggregateLoading &&
+                !isSegmentInfoAggregateError && 
+              segmentInfoAggregateData!.subSegments.length > 0 ? (
+                segmentInfoAggregateData!.subSegments.map((subSeg) => (
                   <ListGroup.Item
                     action
                     onClick={() => handleCommunityChange(subSeg, "SubSegment")}
@@ -284,7 +343,7 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
                   </ListGroup.Item>
                 ))
               ) : (
-                <ListGroup.Item>No subSegments</ListGroup.Item>
+                <ListGroup.Item>No neighbourhoods found.</ListGroup.Item>
               )}
             </ListGroup>
           </Card>

--- a/frontend/src/components/content/CommunityDashboardContent.tsx
+++ b/frontend/src/components/content/CommunityDashboardContent.tsx
@@ -192,7 +192,11 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
       <Row className="mb-4 mt-4 justify-content-left">
         <h1 className="pb-2 pt-2 display-6">Community:</h1>
         {(isSegmentIdsLoading || isSegmentDataLoading) && (
-          <LoadingSpinnerInline />
+          <Row className="align-items-center">
+            <Col>
+              <LoadingSpinnerInline />
+            </Col>
+          </Row>
         )}
         {(isSegmentIdsError || isSegmentDataError) && (
           <ErrorMessage message="Error loading available communities." />
@@ -222,7 +226,7 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
           <Card style={{ width: "25rem" }}>
             {isSegmentInfoAggregateLoading && <LoadingSpinnerInline />}
             {!isSegmentInfoAggregateLoading && isSegmentInfoAggregateError && (
-              <ErrorMessage message="There was an error loading user statistics." />
+              <ErrorMessage message="Unable to load user statistics." />
             )}
             {!isSegmentInfoAggregateLoading && !isSegmentInfoAggregateError && (
               <Row className="justify-content-center mt-3 mb-3">
@@ -264,7 +268,7 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
           <Card style={{ width: "25rem" }}>
             {isSegmentInfoAggregateLoading && <LoadingSpinnerInline />}
             {!isSegmentInfoAggregateLoading && isSegmentInfoAggregateError && (
-              <ErrorMessage message="There was an error loading user statistics." />
+              <ErrorMessage message="Unable to load post statistics." />
             )}
             {!isSegmentInfoAggregateLoading && !isSegmentInfoAggregateError && (
               <Row className="justify-content-center mt-3 mb-3">
@@ -382,19 +386,21 @@ const CommunityDashboardContent: React.FC<CommunityDashboardContentProps> = ({
                   <ErrorMessage message="Unable to load region." />
                 )}
               {!isSegmentInfoAggregateLoading &&
-              !isSegmentInfoAggregateError &&
-              segmentInfoAggregateData!.subSegments.length > 0 ? (
-                segmentInfoAggregateData!.subSegments.map((subSeg) => (
-                  <ListGroup.Item
-                    action
-                    onClick={() => handleCommunityChange(subSeg, "SubSegment")}
-                  >
-                    {capitalizeFirstLetterEachWord(subSeg)}
-                  </ListGroup.Item>
-                ))
-              ) : (
-                <ListGroup.Item>No neighbourhoods found.</ListGroup.Item>
-              )}
+                !isSegmentInfoAggregateError &&
+                (segmentInfoAggregateData!.subSegments.length > 0 ? (
+                  segmentInfoAggregateData!.subSegments.map((subSeg) => (
+                    <ListGroup.Item
+                      action
+                      onClick={() =>
+                        handleCommunityChange(subSeg, "SubSegment")
+                      }
+                    >
+                      {capitalizeFirstLetterEachWord(subSeg)}
+                    </ListGroup.Item>
+                  ))
+                ) : (
+                  <ListGroup.Item>No neighbourhoods found.</ListGroup.Item>
+                ))}
             </ListGroup>
           </Card>
         </Col>

--- a/frontend/src/components/content/CommunityDashboardContent.tsx
+++ b/frontend/src/components/content/CommunityDashboardContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { useState } from "react";
 import {
   ISegmentAggregateInfo,

--- a/frontend/src/components/partials/CommunityDashboardContent/SpecifiedCommunitySection.tsx
+++ b/frontend/src/components/partials/CommunityDashboardContent/SpecifiedCommunitySection.tsx
@@ -24,7 +24,6 @@ interface SpecifiedCommunityProps {
 const SpecifiedCommunitySection: React.FC<SpecifiedCommunityProps> = ({
   sectionTitle,
   topIdeas,
-  postType,
   isDashboard,
   showCustomFilter,
 }) => {
@@ -197,12 +196,12 @@ const SpecifiedCommunitySection: React.FC<SpecifiedCommunityProps> = ({
 
       {isDashboard ? (
         <div className="pb-1 border-bottom display-6">
-          <h2 style={titleStyle}>{capitalizeFirstLetterEachWord(sectionTitle)} Posts</h2>
+          <h2 style={titleStyle}>{sectionTitle ? capitalizeFirstLetterEachWord(sectionTitle) : ""} Posts</h2>
           {showCustomFilter === false ? null : <BsFilter onMouseOver={mouseHoverPointer} style={filterButtonStyle} onClick={() => {setShowModal(!showModal)}} size={30} />}
         </div>
       ) : (
         <div className="pb-1 border-bottom display-6 text-left">
-          <h2 style={titleStyle}>{capitalizeFirstLetterEachWord(sectionTitle)} Posts</h2>
+          <h2 style={titleStyle}>{sectionTitle ? capitalizeFirstLetterEachWord(sectionTitle) : ""} Posts</h2>
           {showCustomFilter === false ? null : <BsFilter onMouseOver={mouseHoverPointer} style={filterButtonStyle} onClick={() => {setShowModal(!showModal)}} size={30} />}
 
         </div>

--- a/frontend/src/pages/CommunityDashboardPage.tsx
+++ b/frontend/src/pages/CommunityDashboardPage.tsx
@@ -20,12 +20,6 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     } = props;
 
     const { user, token } = useContext(UserProfileContext);
-
-    const {
-      data: segmentAggregateData,
-      isLoading: isAggregateLoading,
-      isError: isAggregateError,
-    } = useSegmentInfoAggregate(parseInt(segId));
     const {
       data: segmentInfoData,
       isLoading: isSegmentInfoLoading,
@@ -37,7 +31,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
       isError: iIsError,
     } = useIdeasHomepage();
     const allUserSegmentsQueryResult = useAllUserSegments(token, user?.id || null);
-    // const segmentInfoAggregateQueryResult = useSegmentInfoAggregate(parseInt(segId));
+    const segmentInfoAggregateQueryResult = useSegmentInfoAggregate(parseInt(segId));
     // if segId == 0 then use segmentIds to set segId to the home segment
     if (parseInt(segId) === 0 && allUserSegmentsQueryResult.data?.homeSegmentId) {
       props.history.push(`/community-dashboard/${allUserSegmentsQueryResult.data.homeSegmentId}`);
@@ -53,7 +47,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     }
 
 
-    if (isAggregateError || isSegmentInfoError || iIsError) {
+    if (isSegmentInfoError || iIsError) {
         return (
           <div className="wrapper">
             <p>
@@ -63,7 +57,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
         );
     }
 
-    if (isAggregateLoading || isSegmentInfoLoading || iIsLoading) {
+    if (isSegmentInfoLoading || iIsLoading) {
         return (
           <div className="wrapper">
             <LoadingSpinner />
@@ -88,10 +82,9 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
         <div className="wrapper">
           <CommunityDashboardContent
             topIdeas={filteredTopIdeas()}
-            data={segmentAggregateData!}
             segmentData={segmentInfoData!}
             allUserSegmentsQueryResult={allUserSegmentsQueryResult}
-            // segmentInfoAggregateQueryResult={segmentInfoAggregateQueryResult}
+            segmentInfoAggregateQueryResult={segmentInfoAggregateQueryResult}
           />
         </div>
       </>

--- a/frontend/src/pages/CommunityDashboardPage.tsx
+++ b/frontend/src/pages/CommunityDashboardPage.tsx
@@ -3,7 +3,6 @@ import CommunityDashboardContent from "./../components/content/CommunityDashboar
 import LoadingSpinner from "../components/ui/LoadingSpinner";
 import { useSegmentInfoAggregate, useSingleSegmentBySegmentId } from "./../hooks/segmentHooks";
 import { useIdeasHomepage } from "src/hooks/ideaHooks";
-import { IIdeaWithAggregations } from "src/lib/types/data/idea.type";
 import { useContext } from "react";
 import { UserProfileContext } from "src/contexts/UserProfile.Context";
 import { useAllUserSegments } from "src/hooks/userSegmentHooks";
@@ -20,14 +19,10 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     } = props;
 
     const { user, token } = useContext(UserProfileContext);
-    const {
-      data: iData,
-      isLoading: iIsLoading,
-      isError: iIsError,
-    } = useIdeasHomepage();
     const allUserSegmentsQueryResult = useAllUserSegments(token, user?.id || null);
     const segmentInfoAggregateQueryResult = useSegmentInfoAggregate(parseInt(segId));
     const singleSegmentBySegmentIdQueryResult = useSingleSegmentBySegmentId(parseInt(segId));
+    const ideasHomepageQueryResult = useIdeasHomepage();
     // if segId == 0 then use segmentIds to set segId to the home segment
     if (parseInt(segId) === 0 && allUserSegmentsQueryResult.data?.homeSegmentId) {
       props.history.push(`/community-dashboard/${allUserSegmentsQueryResult.data.homeSegmentId}`);
@@ -42,48 +37,17 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
         );
     }
 
-
-    if (iIsError) {
-        return (
-          <div className="wrapper">
-            <p>
-              Error occured while trying to retrieve community info. Please try again later.
-            </p>
-          </div>
-        );
-    }
-
-    if (iIsLoading) {
-        return (
-          <div className="wrapper">
-            <LoadingSpinner />
-          </div>
-        );
-    }
-
-    const filteredTopIdeas = () => {
-        const segmentId = singleSegmentBySegmentIdQueryResult.data?.segId;
-        const filteredTopIdeas: IIdeaWithAggregations[] = [];
-        iData && iData.forEach(idea => {
-            if (idea.segId && idea.segId === segmentId || (idea.segId == null && idea.superSegId == singleSegmentBySegmentIdQueryResult.data?.superSegId )) {
-                filteredTopIdeas.push(idea);
-            }
-
-        });
-        return filteredTopIdeas;
-    }
-
     return (
-      <>
-        <div className="wrapper">
-          <CommunityDashboardContent
-            topIdeas={filteredTopIdeas()}
-            allUserSegmentsQueryResult={allUserSegmentsQueryResult}
-            segmentInfoAggregateQueryResult={segmentInfoAggregateQueryResult}
-            singleSegmentBySegmentIdQueryResult={singleSegmentBySegmentIdQueryResult}
-          />
-        </div>
-      </>
+      <div className="wrapper">
+        <CommunityDashboardContent
+          allUserSegmentsQueryResult={allUserSegmentsQueryResult}
+          segmentInfoAggregateQueryResult={segmentInfoAggregateQueryResult}
+          singleSegmentBySegmentIdQueryResult={
+            singleSegmentBySegmentIdQueryResult
+          }
+          ideasHomepageQueryResult={ideasHomepageQueryResult}
+        />
+      </div>
     );
 }
 

--- a/frontend/src/pages/CommunityDashboardPage.tsx
+++ b/frontend/src/pages/CommunityDashboardPage.tsx
@@ -21,17 +21,13 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
 
     const { user, token } = useContext(UserProfileContext);
     const {
-      data: segmentInfoData,
-      isLoading: isSegmentInfoLoading,
-      isError: isSegmentInfoError,
-    } = useSingleSegmentBySegmentId(parseInt(segId));
-    const {
       data: iData,
       isLoading: iIsLoading,
       isError: iIsError,
     } = useIdeasHomepage();
     const allUserSegmentsQueryResult = useAllUserSegments(token, user?.id || null);
     const segmentInfoAggregateQueryResult = useSegmentInfoAggregate(parseInt(segId));
+    const singleSegmentBySegmentIdQueryResult = useSingleSegmentBySegmentId(parseInt(segId));
     // if segId == 0 then use segmentIds to set segId to the home segment
     if (parseInt(segId) === 0 && allUserSegmentsQueryResult.data?.homeSegmentId) {
       props.history.push(`/community-dashboard/${allUserSegmentsQueryResult.data.homeSegmentId}`);
@@ -47,7 +43,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     }
 
 
-    if (isSegmentInfoError || iIsError) {
+    if (iIsError) {
         return (
           <div className="wrapper">
             <p>
@@ -57,7 +53,7 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
         );
     }
 
-    if (isSegmentInfoLoading || iIsLoading) {
+    if (iIsLoading) {
         return (
           <div className="wrapper">
             <LoadingSpinner />
@@ -66,10 +62,10 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
     }
 
     const filteredTopIdeas = () => {
-        const segmentId = segmentInfoData?.segId;
+        const segmentId = singleSegmentBySegmentIdQueryResult.data?.segId;
         const filteredTopIdeas: IIdeaWithAggregations[] = [];
         iData && iData.forEach(idea => {
-            if (idea.segId && idea.segId === segmentId || (idea.segId == null && idea.superSegId == segmentInfoData?.superSegId )) {
+            if (idea.segId && idea.segId === segmentId || (idea.segId == null && idea.superSegId == singleSegmentBySegmentIdQueryResult.data?.superSegId )) {
                 filteredTopIdeas.push(idea);
             }
 
@@ -82,9 +78,9 @@ const CommunityDashboardPage: React.FC<CommunityDashboardPageProps> = (props) =>
         <div className="wrapper">
           <CommunityDashboardContent
             topIdeas={filteredTopIdeas()}
-            segmentData={segmentInfoData!}
             allUserSegmentsQueryResult={allUserSegmentsQueryResult}
             segmentInfoAggregateQueryResult={segmentInfoAggregateQueryResult}
+            singleSegmentBySegmentIdQueryResult={singleSegmentBySegmentIdQueryResult}
           />
         </div>
       </>


### PR DESCRIPTION
Old behavior: community dashboard page shows a page-wide loading spinner until every api request goes through before rendering child components; shows a generic error message if even one request fails

New behavior: community dashboard page loads child components immediately, child components show individual loading spinners and error messages depending on the state of their required api requests

<img width="1301" alt="image" src="https://github.com/MyLivingCity/my-living-city/assets/112919426/03f55812-9476-4d94-a261-2c155ccf246f">
