### PR TITLE
Fix/feedback rating not updating/langelozzi

### DIFF
--- a/frontend/src/components/partials/SingleIdeaContent/FeedbackRatingInput.tsx
+++ b/frontend/src/components/partials/SingleIdeaContent/FeedbackRatingInput.tsx
@@ -14,6 +14,7 @@ interface FeedbackRatingInputProps {
     userSubmittedRating: number | null;
     proposalId: string;
     feedbackId: string;
+    refetchData: () => void;
 }
 
 const FeedbackRatingYesNoInput = ({
@@ -21,6 +22,7 @@ const FeedbackRatingYesNoInput = ({
     feedbackId,
     userHasRated,
     userSubmittedRating,
+    refetchData
 }: FeedbackRatingInputProps) => {
     const { token, user } = useContext(UserProfileContext);
     const [ratingValue, setRatingValue] = useState<number>(
@@ -35,8 +37,8 @@ const FeedbackRatingYesNoInput = ({
         error,
         isSuccess,
     } = useCreateFeedbackRatingMutation(
-        parseInt(proposalId),
         parseInt(feedbackId),
+        parseInt(proposalId),
         token,
         user
     );
@@ -46,6 +48,10 @@ const FeedbackRatingYesNoInput = ({
     useEffect(() => {
         setShowRatingSubmitError(isError);
     }, [isError]);
+
+    useEffect(() => {
+        refetchData();
+    }, [isSuccess]);
 
     const submitHandler = () => {
         const payload = {
@@ -165,6 +171,7 @@ const FeedbackRatingScaleInput = ({
     feedbackId,
     userHasRated,
     userSubmittedRating,
+    refetchData
 }: FeedbackRatingInputProps) => {
     const { token, user } = useContext(UserProfileContext);
     const [ratingValue, setRatingValue] = useState<number>(
@@ -190,6 +197,10 @@ const FeedbackRatingScaleInput = ({
     useEffect(() => {
         setShowRatingSubmitError(isError);
     }, [isError]);
+
+    useEffect(() => {
+        refetchData();
+    }, [isSuccess]);
 
     const submitHandler = () => {
         const payload = {

--- a/frontend/src/components/partials/SingleIdeaContent/FeedbackRatingSection.tsx
+++ b/frontend/src/components/partials/SingleIdeaContent/FeedbackRatingSection.tsx
@@ -28,6 +28,7 @@ const FeedbackRatingYesNoSection: React.FC<FeedbackRatingsSectionProps> = ({
         isLoading,
         isError,
         error,
+        refetch
     } = useAllFeedbackRatingsUnderFeedback(feedbackId, proposalId);
 
     const [userHasRated, setUserHasRated] = useState<boolean>(
@@ -73,6 +74,7 @@ const FeedbackRatingYesNoSection: React.FC<FeedbackRatingsSectionProps> = ({
                         proposalId={proposalId}
                         userHasRated={userHasRated}
                         userSubmittedRating={userSubmittedRating}
+                        refetchData={refetch}
                     />
                 )}
             </Row>
@@ -91,6 +93,7 @@ const FeedbackRatingScaleSection: React.FC<FeedbackRatingsSectionProps> = ({
         isLoading,
         isError,
         error,
+        refetch
     } = useAllFeedbackRatingsUnderFeedback(feedbackId, proposalId);
 
     const [userHasRated, setUserHasRated] = useState<boolean>(
@@ -137,6 +140,7 @@ const FeedbackRatingScaleSection: React.FC<FeedbackRatingsSectionProps> = ({
                         proposalId={proposalId}
                         userHasRated={userHasRated}
                         userSubmittedRating={userSubmittedRating}
+                        refetchData={refetch}
                     />
                 )}
             </Row>

--- a/frontend/src/hooks/feedbackRatingHooks.tsx
+++ b/frontend/src/hooks/feedbackRatingHooks.tsx
@@ -78,7 +78,7 @@ export const useCreateFeedbackRatingMutation = (feedbackId: number, proposalId: 
             },
         },
     );
-    const { error } = feedbackRatingMutation;
+    const { error, isSuccess, isLoading } = feedbackRatingMutation;
     const [ parsedErrorObj, setParsedErrorObj ] = useState<IFetchError | null>(null);
 
     useEffect(() => {
@@ -99,5 +99,7 @@ export const useCreateFeedbackRatingMutation = (feedbackId: number, proposalId: 
         ...feedbackRatingMutation,
         submitRatingMutation,
         error: parsedErrorObj,
+        isSuccess,
+        isLoading
     };
 };

--- a/server/controllers/feedbackRating.js
+++ b/server/controllers/feedbackRating.js
@@ -11,22 +11,22 @@ feedbackRatingRouter.post(
         try {
             const { id: userId } = req.user;
             const { ratingExplanation, rating } = req.body;
-            const  parsedProposalId = parseInt(req.params.feedbackId); // THESE GOT FLIPPED SOMEHOW BE CAREFUL
-            const  parsedFeedbackId = parseInt(req.params.proposalId);
-          
-            if(!parsedFeedbackId || !parsedProposalId) {
-                return res.status(400).json({ 
-                    message: `A valid ideaId must be specified in the route paramater.`, 
+            const parsedProposalId = parseInt(req.params.proposalId);
+            const parsedFeedbackId = parseInt(req.params.feedbackId);
+
+            if (!parsedFeedbackId || !parsedProposalId) {
+                return res.status(400).json({
+                    message: `A valid ideaId must be specified in the route paramater.`,
                 });
             }
 
-            const foundFeedback = await prisma.proposal.findUnique({ where: {id: parsedProposalId}});
-            if(!foundFeedback) {
+            const foundFeedback = await prisma.proposal.findUnique({ where: { id: parsedProposalId } });
+            if (!foundFeedback) {
                 console.log("PARSEY BOy:  " + parsedProposalId)
                 console.log("FEEDBACKBOY" + parsedFeedbackId)
-                return res.status(404).json({ 
-                    
-                    message: `The propsal with that listed ID (${parsedProposalId}) does not exist.`, 
+                return res.status(404).json({
+
+                    message: `The propsal with that listed ID (${parsedProposalId}) does not exist.`,
                 });
             }
 
@@ -38,12 +38,12 @@ feedbackRatingRouter.post(
                 }
             });
 
-            if(userAlreadyCreatedRating) {
-                return res.status(400).json({ 
+            if (userAlreadyCreatedRating) {
+                return res.status(400).json({
                     message: `You have already rated this feedback. You cannot rate a feedback twice.`,
                     details: {
                         errorMessage: "A rating can only be voted on once."
-                    } 
+                    }
                 });
             }
 
@@ -65,14 +65,14 @@ feedbackRatingRouter.post(
             res.status(400).json({
                 message: `An error occured while trying to create a rating for feedback ${req.params.feedbackId} for proposal ${req.params.proposalId}.`,
                 details: {
-                  errorMessage: error.message,
-                  errorStack: error.stack,
+                    errorMessage: error.message,
+                    errorStack: error.stack,
                 }
-              });
+            });
         } finally {
             await prisma.$disconnect();
         }
-    } 
+    }
 )
 
 feedbackRatingRouter.get(
@@ -95,21 +95,21 @@ feedbackRatingRouter.get(
             }
 
             const ratings = await prisma.feedbackRating.findMany({
-                 where: {
+                where: {
                     proposalId: parsedProposalId,
-                    feedbackId: parsedFeedbackId 
-                } 
+                    feedbackId: parsedFeedbackId
+                }
             });
-            
+
             res.status(200).json(ratings);
-        }  catch (error) {
+        } catch (error) {
             res.status(400).json({
                 message: `An error occured while trying to get all ratings for feedback ${req.params.feedbackId} for proposal ${req.params.proposalId}.`,
                 details: {
-                  errorMessage: error.message,
-                  errorStack: error.stack,
+                    errorMessage: error.message,
+                    errorStack: error.stack,
                 }
-              });
+            });
         } finally {
             await prisma.$disconnect();
         }
@@ -139,12 +139,12 @@ feedbackRatingRouter.get(
 
             const ratings = await prisma.feedbackRating.findMany({
                 where: {
-                   proposalId: parsedProposalId,
-                   feedbackId: parsedFeedbackId 
-               } 
-           });
-           if (req.params.type === "YESNO") {
-            const yesRatings = await prisma.feedbackRating.aggregate({
+                    proposalId: parsedProposalId,
+                    feedbackId: parsedFeedbackId
+                }
+            });
+            if (req.params.type === "YESNO") {
+                const yesRatings = await prisma.feedbackRating.aggregate({
                     where: {
                         proposalId: parsedProposalId,
                         feedbackId: parsedFeedbackId,
@@ -188,15 +188,15 @@ feedbackRatingRouter.get(
             res.status(200).json({
                 ratings,
                 summary,
-                });
-        }  catch (error) {
+            });
+        } catch (error) {
             res.status(400).json({
                 message: `An error occured while trying to get all ratings for feedback ${req.params.feedbackId} for proposal ${req.params.proposalId}.`,
                 details: {
-                  errorMessage: error.message,
-                  errorStack: error.stack,
+                    errorMessage: error.message,
+                    errorStack: error.stack,
                 }
-              });
+            });
         } finally {
             await prisma.$disconnect();
         }


### PR DESCRIPTION
- Updated the POST feedbackRating endpoint so that the url parameters are correctly assigned to the variables
- Add functionality to refetch the feedbackRating data after submitting
- Fix the order of the provided arguments to the mutation hook for the yes/no input

This branch fixes the following two issues:
2024-004: https://trello.com/c/g4M518h1/7-2024-004-as-a-user-when-i-click-yes-or-no-on-specific-feedback-i-want-it-to-increment-the-count-and-remove-the-option-to-click-a
2024-005: https://trello.com/c/25vppQNf/27-2024-005-as-a-user-when-i-click-rate-1-to-5-on-specific-feedback-i-want-it-to-increment-the-count-and-remove-the-option-to-click