### PR TITLE
Fix MUNICIPAL user organization assignment and endorse button functionality

### DIFF
--- a/frontend/src/components/content/AdminManagementContent.tsx
+++ b/frontend/src/components/content/AdminManagementContent.tsx
@@ -53,7 +53,7 @@ export const AdminManagementContent: React.FC<AdminManagementContentProps> = ({
     const [showUserBanModal, setShowUserBanModal] = useState<boolean>(false);
     const [showUserUnbanModal, setShowUserUnbanModal] = useState<boolean>(false);
     const [showUserBanHistoryModal, setShowUserBanHistoryModal] =
-    useState<boolean>(false);
+        useState<boolean>(false);
     const [modalUser, setModalUser] = useState<IUser>();
     const [showCreateAccountForm, setShowCreateAccountForm] = useState(false);
     const [buttonText, setButtonText] = useState('Admin Creation Wizard');
@@ -81,6 +81,7 @@ export const AdminManagementContent: React.FC<AdminManagementContentProps> = ({
     };
 
     const capitalizeString = (s: string) => {
+        if(!s) return '';
         return s.charAt(0).toUpperCase() + s.slice(1);
     };
     const handleDeleteUser = async (userId: string) => {
@@ -97,22 +98,31 @@ export const AdminManagementContent: React.FC<AdminManagementContentProps> = ({
     };
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-        console.log('Made it Submit');
+        // console.log('Submitting form');
 
         const form = event.target as HTMLFormElement;
         const formData = new FormData(form);
-        const selectedCommunity = formData.get('inputCommunity') as string;
-        console.log(selectedCommunity);
-        const homeSegmentId = subSeg.find(
-            (seg) => selectedCommunity === seg.name
-        )?.segId;
-        console.log(homeSegmentId);
+
+        const selectedCommunityId = formData.get('inputCommunity') as string;
+        const selectedUserType = formData.get('inputType') as string;
+
+        const selectedCommunitySeg = subSeg.find(
+            (seg) => seg.segId === parseInt(selectedCommunityId)
+        );
+
+        const communityName = selectedCommunitySeg?.name
+            ? capitalizeString(selectedCommunitySeg.name)
+            : undefined;
+
         const registerData: IRegisterInput = {
             userRoleId: undefined,
             email: formData.get('inputEmail') as string,
             password: formData.get('inputPassword') as string,
             confirmPassword: formData.get('inputPassword') as string,
-            organizationName: undefined,
+            organizationName:
+                selectedUserType === USER_TYPES.MUNICIPAL_SEG_ADMIN
+                    ? communityName
+                    : undefined,
             fname: formData.get('inputFirst') as string,
             lname: formData.get('inputLast') as string,
             displayFName: formData.get('inputFirst') as string,
@@ -143,14 +153,13 @@ export const AdminManagementContent: React.FC<AdminManagementContentProps> = ({
                 faculty: '',
                 programCompletionDate: new Date(),
             },
-
-            homeSegmentId: parseInt(formData.get('inputCommunity') as string),
+            homeSegmentId: parseInt(selectedCommunityId),
             workSegmentId: undefined,
             schoolSegmentId: undefined,
             homeSubSegmentId: undefined,
             workSubSegmentId: undefined,
             schoolSubSegmentId: undefined,
-            userType: formData.get('inputType') as string,
+            userType: selectedUserType,
             reachSegmentIds: [],
             verified: true,
         };
@@ -280,9 +289,7 @@ export const AdminManagementContent: React.FC<AdminManagementContentProps> = ({
                             <Form.Control
                                 as='select'
                                 name='inputCommunity'
-                                onChange={(event) => {
-                                    newHomeID = parseInt(event.target.value);
-                                }}
+                                required
                             >
                                 <option value=''>Select Community</option>
                                 {subSeg
@@ -344,193 +351,193 @@ export const AdminManagementContent: React.FC<AdminManagementContentProps> = ({
                 <tbody>
                     {users?.map((req: IUser, index: number) =>
                         req.userType === 'SUPER_ADMIN' ||
-                        req.userType === 'ADMIN' ||
-                        req.userType === 'MUNICIPAL_SEG_ADMIN' ||
-                        req.userType === 'MOD' ||
-                        req.userType === 'SEG_MOD' ||
-                        req.userType === 'SEG_ADMIN' ? (
-                                <tr key={req.id}>
+                            req.userType === 'ADMIN' ||
+                            req.userType === 'MUNICIPAL_SEG_ADMIN' ||
+                            req.userType === 'MOD' ||
+                            req.userType === 'SEG_MOD' ||
+                            req.userType === 'SEG_ADMIN' ? (
+                            <tr key={req.id}>
+                                {req.id !== hideControls ? (
+                                    <>
+                                        <td className='text-left align-middle' style={{ wordBreak: 'break-word' }}>{req.email}</td>
+                                        <td className='text-left align-middle '>{req.fname}</td>
+                                        <td className='text-left align-middle'>{req.lname}</td>
+                                        <td className='text-left align-middle' style={{ wordBreak: 'break-word' }}> {req.adminmodEmail}</td>
+                                        <td className='text-center align-middle'>{req.userType}</td>
+                                        <td className='text-center align-middle'>
+                                            {req.userType === 'SUPER_ADMIN' ? (
+                                                'Full access'
+                                            ) : (
+                                                <UserSegPlainText
+                                                    email={req.email}
+                                                    id={req.id}
+                                                    token={token}
+                                                />
+                                            )}
+                                        </td>
+                                        <td className='text-center align-middle'>
+                                            {new Date(req.createdAt).toISOString().split('T')[0]}
+                                        </td>
+                                        <td className='text-left align-middle'>
+                                            {req.status ? 'Active' : 'Inactive'}
+                                        </td>
+                                    </>
+                                ) : (
+                                    <>
+                                        <td className='text-left align-middle'>
+                                            <Form.Control
+                                                type='text'
+                                                defaultValue={req.email}
+                                                onChange={(e) => (req.email = e.target.value)}
+                                            />
+                                        </td>
+                                        <td className='text-left align-middle'>
+                                            <Form.Control
+                                                type='text'
+                                                defaultValue={req.fname}
+                                                onChange={(e) => (req.fname = e.target.value)}
+                                            />
+                                        </td>
+                                        <td className='text-left align-middle'>
+                                            <Form.Control
+                                                type='text'
+                                                defaultValue={req.lname}
+                                                onChange={(e) => (req.lname = e.target.value)}
+                                            />
+                                        </td>
+                                        <td className='text-left align-middle'>
+                                            <Form.Control
+                                                as='select'
+                                                onChange={(e) => {
+                                                    (req.userType as String) = e.target.value;
+                                                }}
+                                            >
+                                                <option className='text-center align-middle'>
+                                                    {req.userType}
+                                                </option>
+                                                {userTypes
+                                                    .filter((type) => type !== req.userType)
+                                                    .filter((type) => type !== 'DEVELOPER')
+                                                    .filter((type) => type !== 'IN_PROGRESS')
+                                                    .filter((type) => type !== 'ASSOCIATE')
+                                                    .filter((type) => type !== 'RESIDENTIAL')
+                                                    .filter((type) => type !== 'COMMUNITY')
+                                                    .filter((type) => type !== 'BUSINESS')
+                                                    .map((item) => (
+                                                        <option key={item}>{item}</option>
+                                                    ))}
+                                            </Form.Control>
+                                        </td>
+
+                                        <td className='text-center align-middle'>
+                                            {req.userType === 'SUPER_ADMIN' ? (
+                                                'Full access'
+                                            ) : (
+                                                <UserSegPlainText
+                                                    email={req.email}
+                                                    id={req.id}
+                                                    token={token}
+                                                />
+                                            )}
+                                        </td>
+                                        <td className='text-center align-middle'>
+                                            {new Date(req.createdAt).toISOString().split('T')[0]}
+                                        </td>
+                                        <td className='text-center align-middle'>
+                                            <Form.Check
+                                                type='switch'
+                                                checked={status}
+                                                onChange={(e) => {
+                                                    setStatus(e.target.checked);
+                                                    req.status = e.target.checked;
+                                                }}
+                                                id='status-switch'
+                                            />
+                                        </td>
+                                    </>
+                                )}
+
+                                <td>
                                     {req.id !== hideControls ? (
-                                        <>
-                                            <td className='text-left align-middle' style={{wordBreak: 'break-word'}}>{req.email}</td>
-                                            <td className='text-left align-middle '>{req.fname}</td>
-                                            <td className='text-left align-middle'>{req.lname}</td>
-                                            <td className='text-left align-middle' style={{wordBreak: 'break-word'}}> {req.adminmodEmail}</td>
-                                            <td className='text-center align-middle'>{req.userType}</td>
-                                            <td className='text-center align-middle'>
-                                                {req.userType === 'SUPER_ADMIN' ? (
-                                                    'Full access'
-                                                ) : (
-                                                    <UserSegPlainText
-                                                        email={req.email}
-                                                        id={req.id}
-                                                        token={token}
-                                                    />
-                                                )}
-                                            </td>
-                                            <td className='text-center align-middle'>
-                                                {new Date(req.createdAt).toISOString().split('T')[0]}
-                                            </td>
-                                            <td className='text-left align-middle'>
-                                                {req.status ? 'Active' : 'Inactive'}
-                                            </td>
-                                        </>
-                                    ) : (
-                                        <>
-                                            <td className='text-left align-middle'>
-                                                <Form.Control
-                                                    type='text'
-                                                    defaultValue={req.email}
-                                                    onChange={(e) => (req.email = e.target.value)}
-                                                />
-                                            </td>
-                                            <td className='text-left align-middle'>
-                                                <Form.Control
-                                                    type='text'
-                                                    defaultValue={req.fname}
-                                                    onChange={(e) => (req.fname = e.target.value)}
-                                                />
-                                            </td>
-                                            <td className='text-left align-middle'>
-                                                <Form.Control
-                                                    type='text'
-                                                    defaultValue={req.lname}
-                                                    onChange={(e) => (req.lname = e.target.value)}
-                                                />
-                                            </td>
-                                            <td className='text-left align-middle'>
-                                                <Form.Control
-                                                    as='select'
-                                                    onChange={(e) => {
-                                                        (req.userType as String) = e.target.value;
-                                                    }}
-                                                >
-                                                    <option className='text-center align-middle'>
-                                                        {req.userType}
-                                                    </option>
-                                                    {userTypes
-                                                        .filter((type) => type !== req.userType)
-                                                        .filter((type) => type !== 'DEVELOPER')
-                                                        .filter((type) => type !== 'IN_PROGRESS')
-                                                        .filter((type) => type !== 'ASSOCIATE')
-                                                        .filter((type) => type !== 'RESIDENTIAL')
-                                                        .filter((type) => type !== 'COMMUNITY')
-                                                        .filter((type) => type !== 'BUSINESS')
-                                                        .map((item) => (
-                                                            <option key={item}>{item}</option>
-                                                        ))}
-                                                </Form.Control>
-                                            </td>
-
-                                            <td className='text-center align-middle'>
-                                                {req.userType === 'SUPER_ADMIN' ? (
-                                                    'Full access'
-                                                ) : (
-                                                    <UserSegPlainText
-                                                        email={req.email}
-                                                        id={req.id}
-                                                        token={token}
-                                                    />
-                                                )}
-                                            </td>
-                                            <td className='text-center align-middle'>
-                                                {new Date(req.createdAt).toISOString().split('T')[0]}
-                                            </td>
-                                            <td className='text-center align-middle'>
-                                                <Form.Check
-                                                    type='switch'
-                                                    checked={status}
-                                                    onChange={(e) => {
-                                                        setStatus(e.target.checked);
-                                                        req.status = e.target.checked;
-                                                    }}
-                                                    id='status-switch'
-                                                />
-                                            </td>
-                                        </>
-                                    )}
-
-                                    <td>
-                                        {req.id !== hideControls ? (
-                                            <NavDropdown title='Controls' id='nav-dropdown'>
-                                                <Dropdown.Item
-                                                    onClick={() => UserSegmentHandler(req.email, req.id)}
-                                                >
-                                                    View Segments
-                                                </Dropdown.Item>
-                                                {req.userType !== 'SUPER_ADMIN' && user?.userType != req.userType? (
-                                                    <>
-                                                        <Dropdown.Item
-                                                            onClick={() => {
-                                                                setHideControls(req.id);
-                                                                setReviewed(req.reviewed);
-                                                                setModalUser(req);
-                                                            }}
-                                                        >
-                                                            Edit
-                                                        </Dropdown.Item>
-                                                        {req.banned ? (
-                                                            <Dropdown.Item
-                                                                onClick={() => {
-                                                                    setModalUser(req);
-                                                                    setShowUserUnbanModal(true);
-                                                                }}
-                                                            >
-                                                                Modify Ban
-                                                            </Dropdown.Item>
-                                                        ) : (
-                                                            <Dropdown.Item
-                                                                onClick={() => {
-                                                                    setModalUser(req);
-                                                                    setShowUserBanModal(true);
-                                                                }}
-                                                            >
-                                                                Ban User
-                                                            </Dropdown.Item>
-                                                        )}
-                                                        <Dropdown.Item
-                                                            onClick={() => {
-                                                                const confirmed = window.confirm(
-                                                                    'Are you sure you want to delete this user?'
-                                                                );
-                                                                if (confirmed) {
-                                                                    handleDeleteUser(req.id);
-                                                                }
-                                                            }}
-                                                            className='text-danger'
-                                                        >
-                                                            Delete
-                                                        </Dropdown.Item>
-                                                    </>
-                                                ) : null}
-                                            </NavDropdown>
-                                        ) : (
-                                            <>
-                                                <div className='d-flex justify-content-between'>
-                                                    <Button
-                                                        size='sm'
-                                                        variant='outline-danger'
-                                                        className='mr-2 mb-2 '
-                                                        onClick={() => setHideControls('')}
-                                                    >
-                                                        Cancel
-                                                    </Button>
-                                                    <Button
-                                                        size='sm'
-                                                        className='mr-2 mb-2'
+                                        <NavDropdown title='Controls' id='nav-dropdown'>
+                                            <Dropdown.Item
+                                                onClick={() => UserSegmentHandler(req.email, req.id)}
+                                            >
+                                                View Segments
+                                            </Dropdown.Item>
+                                            {req.userType !== 'SUPER_ADMIN' && user?.userType != req.userType ? (
+                                                <>
+                                                    <Dropdown.Item
                                                         onClick={() => {
-                                                            setHideControls('');
-                                                            updateUser(req, token, user);
+                                                            setHideControls(req.id);
+                                                            setReviewed(req.reviewed);
+                                                            setModalUser(req);
                                                         }}
                                                     >
-                                                        Save
-                                                    </Button>
-                                                </div>
-                                            </>
-                                        )}
-                                    </td>
-                                </tr>
-                            ) : null
+                                                        Edit
+                                                    </Dropdown.Item>
+                                                    {req.banned ? (
+                                                        <Dropdown.Item
+                                                            onClick={() => {
+                                                                setModalUser(req);
+                                                                setShowUserUnbanModal(true);
+                                                            }}
+                                                        >
+                                                            Modify Ban
+                                                        </Dropdown.Item>
+                                                    ) : (
+                                                        <Dropdown.Item
+                                                            onClick={() => {
+                                                                setModalUser(req);
+                                                                setShowUserBanModal(true);
+                                                            }}
+                                                        >
+                                                            Ban User
+                                                        </Dropdown.Item>
+                                                    )}
+                                                    <Dropdown.Item
+                                                        onClick={() => {
+                                                            const confirmed = window.confirm(
+                                                                'Are you sure you want to delete this user?'
+                                                            );
+                                                            if (confirmed) {
+                                                                handleDeleteUser(req.id);
+                                                            }
+                                                        }}
+                                                        className='text-danger'
+                                                    >
+                                                        Delete
+                                                    </Dropdown.Item>
+                                                </>
+                                            ) : null}
+                                        </NavDropdown>
+                                    ) : (
+                                        <>
+                                            <div className='d-flex justify-content-between'>
+                                                <Button
+                                                    size='sm'
+                                                    variant='outline-danger'
+                                                    className='mr-2 mb-2 '
+                                                    onClick={() => setHideControls('')}
+                                                >
+                                                    Cancel
+                                                </Button>
+                                                <Button
+                                                    size='sm'
+                                                    className='mr-2 mb-2'
+                                                    onClick={() => {
+                                                        setHideControls('');
+                                                        updateUser(req, token, user);
+                                                    }}
+                                                >
+                                                    Save
+                                                </Button>
+                                            </div>
+                                        </>
+                                    )}
+                                </td>
+                            </tr>
+                        ) : null
                     )}
                 </tbody>
             </Table>

--- a/frontend/src/components/content/SingleIdeaPageContent.tsx
+++ b/frontend/src/components/content/SingleIdeaPageContent.tsx
@@ -45,6 +45,7 @@ import DropdownButton from 'react-bootstrap/DropdownButton';
 import Form from 'react-bootstrap/Form';
 import { useCheckFlagBan } from 'src/hooks/flagHooks';
 import EndorsedUsersSection from '../partials/SingleIdeaContent/EndorsedUsersSection';
+import { IUser } from 'src/lib/types/data/user.type';
 
 interface SingleIdeaPageContentProps {
     ideaData: IIdeaWithRelationship;
@@ -152,35 +153,75 @@ const SingleIdeaPageContent: React.FC<SingleIdeaPageContentProps> = ({
     const handleCloseOther = () => setShowOther(false);
     const handleShowOther = () => setShowOther(true);
 
-    const canEndorse = user?.userType === USER_TYPES.BUSINESS || user?.userType === USER_TYPES.COMMUNITY
+    const [showEndorseButton, setShowEndorseButton] = useState(false);
+    const [userCanEndorseByOrg, setUserCanEndorseByOrg] = useState(true);
+
+    const canEndorseByUserType = user?.userType === USER_TYPES.BUSINESS || user?.userType === USER_TYPES.COMMUNITY
         || user?.userType === USER_TYPES.MUNICIPAL || user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN;
+
+    const canEndorse = canEndorseByUserType && userCanEndorseByOrg;
+
 
     useEffect(() => {
         if (!isEndorsingPostLoading) {
             setEndorsingPost(isEndorsingPost.isEndorsed);
+            setShowEndorseButton(true);
         }
     }, [isEndorsingPostLoading, isEndorsingPost]);
+
+
+    useEffect(() => {
+        if (!isEndorsedUsersDataLoading) {
+            setEndorsedUsers(endorsedUsersData);
+            // Check if current user's organizationName is in endorsements
+            if (user && user.organizationName) {
+                const endorsedOrgNames = endorsedUsersData
+                    .filter((u: IUser) => u.id !== user.id) // Exclude current user
+                    .map((u: IUser) => u.organizationName)
+                    .filter(Boolean); // Remove undefined or null values
+                if (endorsedOrgNames.includes(user.organizationName)) {
+                    setUserCanEndorseByOrg(false);
+                } else {
+                    setUserCanEndorseByOrg(true);
+                }
+            }
+        }
+    }, [isEndorsedUsersDataLoading, endorsedUsersData, user]);
 
     const handleEndorseUnendorse = async () => {
         if (user && token) {
             if (endorsingPost) {
-                await unendorseIdeaByUser(token, user.id, ideaId);
-                const newEndorsedUsers = endorsedUsers.filter(u => u.id !== user.id);
+                // Check if user is the one who endorsed
+                const userEndorsement = endorsedUsers.find(u => u.id === user.id);
+
+                // Check if user is an admin trying to unendorse someone from their organization, not currently working properly
+                const isAdminOfOrg = user.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN;
+                const targetEndorsement = endorsedUsers.find(u => u.organizationName === user.organizationName);
+                const canAdminUnendorse = isAdminOfOrg && targetEndorsement;
+                // console.log(isAdminOfOrg)
+
+                if (!userEndorsement && !canAdminUnendorse) {
+                    alert("You don't have permission to unendorse this post");
+                    return;
+                }
+
+                // If admin is unendorsing someone else's endorsement
+                const endorsementToRemove = userEndorsement ? user.id : targetEndorsement.id;
+
+                await unendorseIdeaByUser(token, endorsementToRemove, ideaId);
+                const newEndorsedUsers = endorsedUsers.filter(u => u.id !== endorsementToRemove);
                 setEndorsedUsers(newEndorsedUsers);
+                setUserCanEndorseByOrg(true);
             } else {
                 await endorseIdeaByUser(token, user.id, ideaId);
                 const newEndorsedUsers = [...endorsedUsers, user];
                 setEndorsedUsers(newEndorsedUsers);
+                setUserCanEndorseByOrg(false);
             }
             setEndorsingPost(!endorsingPost);
         }
     };
 
-    useEffect(() => {
-        if (!isEndorsedUsersDataLoading) {
-            setEndorsedUsers(endorsedUsersData);
-        }
-    }, [isEndorsedUsersDataLoading, endorsedUsersData]);
 
     useEffect(() => {
         if (!isFollowingPostLoading) {
@@ -364,9 +405,11 @@ const SingleIdeaPageContent: React.FC<SingleIdeaPageContentProps> = ({
                                             <LoadingSpinnerInline />
                                         ) : (
                                             <ButtonGroup className='mr-2'>
-                                                {user && canEndorse ? (
+                                                {user && token && showEndorseButton && canEndorseByUserType ? (
                                                     <Button
                                                         onClick={async () => await handleEndorseUnendorse()}
+                                                        disabled={!canEndorse && !endorsingPost} // Allow unendorsing even if organization already endorsed
+                                                        title={!canEndorse && !endorsingPost ? 'Your organization has already endorsed this proposal' : ''}
                                                     >
                                                         {endorsingPost ? 'Unendorse' : 'Endorse'}
                                                     </Button>

--- a/frontend/src/components/content/SingleProposalPageContent.tsx
+++ b/frontend/src/components/content/SingleProposalPageContent.tsx
@@ -113,10 +113,10 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
         projectInfo,
     } = ideaData;
 
-    console.log('segment', segment);
-    console.log('sub segment', subSegment);
-    console.log('super segment', superSegment);
-    console.log('ideaData', ideaData);
+    // console.log('segment', segment);
+    // console.log('sub segment', subSegment);
+    // console.log('super segment', superSegment);
+    // console.log('ideaData', ideaData);
 
     const {
         id: proposalId,
@@ -373,9 +373,9 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
     const commentAggregateUnderIdea = useCommentAggregateUnderIdea(ideaId);
     const allCommentsUnderIdea = useAllCommentsUnderIdea(ideaId, token);
 
-    const canEndorse = user?.userType === USER_TYPES.BUSINESS || user?.userType === USER_TYPES.COMMUNITY
-        || user?.userType === USER_TYPES.MUNICIPAL || user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN;
+ 
     const [showEndorseButton, setShowEndorseButton] = useState(false);
+    const [userCanEndorseByOrg, setUserCanEndorseByOrg] = useState(true);
 
     useEffect(() => {
         if (!isEndorsingPostLoading) {
@@ -402,8 +402,26 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
     useEffect(() => {
         if (!isEndorsedUsersDataLoading) {
             setEndorsedUsers(endorsedUsersData);
+            // Check if current user's organizationName is in endorsements
+            if (user && user.organizationName) {
+                const endorsedOrgNames = endorsedUsersData
+                    .map((u: IUser) => u.organizationName)
+                    .filter(Boolean); // Remove undefined or null values
+                if (endorsedOrgNames.includes(user.organizationName)) {
+                    setUserCanEndorseByOrg(false);
+                    console.log(endorsedOrgNames)
+                } else {
+                    setUserCanEndorseByOrg(true);
+                }
+            }
         }
-    }, [isEndorsedUsersDataLoading, endorsedUsersData]);
+    }, [isEndorsedUsersDataLoading, endorsedUsersData, user]);
+
+    const canEndorseByUserType = user?.userType === USER_TYPES.BUSINESS || user?.userType === USER_TYPES.COMMUNITY
+        || user?.userType === USER_TYPES.MUNICIPAL || user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN;
+
+    const canEndorse = canEndorseByUserType && userCanEndorseByOrg;
+
 
     const [showFollowButton, setShowFollowButton] = useState(false);
     useEffect(() => {
@@ -424,9 +442,9 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
 
     useEffect(() => {
         if (!isFlaggedLoading) {
-            console.log('isFlagged', isFlagged?.valueOf());
+            // console.log('isFlagged', isFlagged?.valueOf());
             if (isFlagged) {
-                console.log('isFlaggedRAWR', isFlagged?.valueOf());
+                // console.log('isFlaggedRAWR', isFlagged?.valueOf());
                 handleHideFlagButton();
             }
         }
@@ -525,7 +543,7 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
         const { subSegmentId, segmentId, superSegmentId, author } = ideaData;
 
         if (!author) return;
-        
+
         if (subSegmentId) {
             return getHandleBySegmentId(subSegmentId, author);
         } else if (segmentId) {
@@ -600,11 +618,15 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
                                             </Button> : null}
                                         </ButtonGroup>
                                         <ButtonGroup className='mr-2'>
-                                            {user && token && showEndorseButton && canEndorse ? <Button
-                                                onClick={async () => await handleEndorseUnendorse()}
-                                            >
-                                                {endorsingPost ? 'Unendorse' : 'Endorse'}
-                                            </Button> : null}
+                                            {user && token && showEndorseButton && canEndorseByUserType ? (
+                                                <Button
+                                                    onClick={async () => await handleEndorseUnendorse()}
+                                                    disabled={!canEndorse}
+                                                    title={!canEndorse ? 'Your organization has already endorsed this proposal' : ''}
+                                                >
+                                                    {endorsingPost ? 'Unendorse' : 'Endorse'}
+                                                </Button>
+                                            ) : null}
                                         </ButtonGroup>
                                     </div>
                                 </div>
@@ -1319,7 +1341,7 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
                                 </h4>
                             </div>
                         </Card.Header>
-                        <Card.Body style={{padding: 0}}>
+                        <Card.Body style={{ padding: 0 }}>
                             {suggestedIdeas.length > 0 ? (
                                 <SuggestedIdeasTable suggestedIdeas={suggestedIdeas} />
                             ) : (

--- a/frontend/src/components/content/SingleProposalPageContent.tsx
+++ b/frontend/src/components/content/SingleProposalPageContent.tsx
@@ -377,12 +377,37 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
     const [showEndorseButton, setShowEndorseButton] = useState(false);
     const [userCanEndorseByOrg, setUserCanEndorseByOrg] = useState(true);
 
+    const canEndorseByUserType = user?.userType === USER_TYPES.BUSINESS || user?.userType === USER_TYPES.COMMUNITY
+        || user?.userType === USER_TYPES.MUNICIPAL || user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN;
+
+    const canEndorse = canEndorseByUserType && userCanEndorseByOrg;
+
+
     useEffect(() => {
         if (!isEndorsingPostLoading) {
             setEndorsingPost(isEndorsingPost.isEndorsed);
             setShowEndorseButton(true);
         }
     }, [isEndorsingPostLoading, isEndorsingPost]);
+
+
+    useEffect(() => {
+        if (!isEndorsedUsersDataLoading) {
+            setEndorsedUsers(endorsedUsersData);
+            // Check if current user's organizationName is in endorsements
+            if (user && user.organizationName) {
+                const endorsedOrgNames = endorsedUsersData
+                    .filter((u: IUser) => u.id !== user.id) // Exclude current user
+                    .map((u: IUser) => u.organizationName)
+                    .filter(Boolean); // Remove undefined or null values
+                if (endorsedOrgNames.includes(user.organizationName)) {
+                    setUserCanEndorseByOrg(false);
+                } else {
+                    setUserCanEndorseByOrg(true);
+                }
+            }
+        }
+    }, [isEndorsedUsersDataLoading, endorsedUsersData, user]);
 
     const handleEndorseUnendorse = async () => {
         if (user && token) {
@@ -417,29 +442,6 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
             setEndorsingPost(!endorsingPost);
         }
     };
-
-    useEffect(() => {
-        if (!isEndorsedUsersDataLoading) {
-            setEndorsedUsers(endorsedUsersData);
-            // Check if current user's organizationName is in endorsements
-            if (user && user.organizationName) {
-                const endorsedOrgNames = endorsedUsersData
-                    .filter((u: IUser) => u.id !== user.id) // Exclude current user
-                    .map((u: IUser) => u.organizationName)
-                    .filter(Boolean); // Remove undefined or null values
-                if (endorsedOrgNames.includes(user.organizationName)) {
-                    setUserCanEndorseByOrg(false);
-                } else {
-                    setUserCanEndorseByOrg(true);
-                }
-            }
-        }
-    }, [isEndorsedUsersDataLoading, endorsedUsersData, user]);
-
-    const canEndorseByUserType = user?.userType === USER_TYPES.BUSINESS || user?.userType === USER_TYPES.COMMUNITY
-        || user?.userType === USER_TYPES.MUNICIPAL || user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN;
-
-    const canEndorse = canEndorseByUserType && userCanEndorseByOrg;
 
 
     const [showFollowButton, setShowFollowButton] = useState(false);

--- a/frontend/src/components/content/SingleProposalPageContent.tsx
+++ b/frontend/src/components/content/SingleProposalPageContent.tsx
@@ -373,7 +373,7 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
     const commentAggregateUnderIdea = useCommentAggregateUnderIdea(ideaId);
     const allCommentsUnderIdea = useAllCommentsUnderIdea(ideaId, token);
 
- 
+
     const [showEndorseButton, setShowEndorseButton] = useState(false);
     const [userCanEndorseByOrg, setUserCanEndorseByOrg] = useState(true);
 
@@ -387,13 +387,32 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
     const handleEndorseUnendorse = async () => {
         if (user && token) {
             if (endorsingPost) {
-                await unendorseIdeaByUser(token, user.id, ideaId);
-                const newEndorsedUsers = endorsedUsers.filter(u => u.id !== user.id);
+                // Check if user is the one who endorsed
+                const userEndorsement = endorsedUsers.find(u => u.id === user.id);
+                
+                // Check if user is an admin trying to unendorse someone from their organization, not currently working properly
+                const isAdminOfOrg = user.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN;
+                const targetEndorsement = endorsedUsers.find(u => u.organizationName === user.organizationName);
+                const canAdminUnendorse = isAdminOfOrg && targetEndorsement;
+                // console.log(isAdminOfOrg)
+    
+                if (!userEndorsement && !canAdminUnendorse) {
+                    alert("You don't have permission to unendorse this post");
+                    return;
+                }
+    
+                // If admin is unendorsing someone else's endorsement
+                const endorsementToRemove = userEndorsement ? user.id : targetEndorsement.id;
+    
+                await unendorseIdeaByUser(token, endorsementToRemove, ideaId);
+                const newEndorsedUsers = endorsedUsers.filter(u => u.id !== endorsementToRemove);
                 setEndorsedUsers(newEndorsedUsers);
+                setUserCanEndorseByOrg(true);
             } else {
                 await endorseIdeaByUser(token, user.id, ideaId);
                 const newEndorsedUsers = [...endorsedUsers, user];
                 setEndorsedUsers(newEndorsedUsers);
+                setUserCanEndorseByOrg(false);
             }
             setEndorsingPost(!endorsingPost);
         }
@@ -405,11 +424,11 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
             // Check if current user's organizationName is in endorsements
             if (user && user.organizationName) {
                 const endorsedOrgNames = endorsedUsersData
+                    .filter((u: IUser) => u.id !== user.id) // Exclude current user
                     .map((u: IUser) => u.organizationName)
                     .filter(Boolean); // Remove undefined or null values
                 if (endorsedOrgNames.includes(user.organizationName)) {
                     setUserCanEndorseByOrg(false);
-                    console.log(endorsedOrgNames)
                 } else {
                     setUserCanEndorseByOrg(true);
                 }
@@ -621,8 +640,8 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
                                             {user && token && showEndorseButton && canEndorseByUserType ? (
                                                 <Button
                                                     onClick={async () => await handleEndorseUnendorse()}
-                                                    disabled={!canEndorse}
-                                                    title={!canEndorse ? 'Your organization has already endorsed this proposal' : ''}
+                                                    disabled={!canEndorse && !endorsingPost} // Allow unendorsing even if organization already endorsed
+                                                    title={!canEndorse && !endorsingPost ? 'Your organization has already endorsed this proposal' : ''}
                                                 >
                                                     {endorsingPost ? 'Unendorse' : 'Endorse'}
                                                 </Button>

--- a/frontend/src/components/content/UserManagementContent.tsx
+++ b/frontend/src/components/content/UserManagementContent.tsx
@@ -176,12 +176,10 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
         if (user?.userType === USER_TYPES.SUPER_ADMIN || 
             user?.userType === USER_TYPES.ADMIN || 
             user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN) {
-            console.log(user?.userType)
       
             // If selected user type is MUNICIPAL or parent is MUNICIPAL_SEG_ADMIN
             if (selectedUserType === USER_TYPES.MUNICIPAL || 
               user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN) {
-                console.log("userType:", user?.userType)
                 // Return organization name of the parent user, or fallback to home segment name
                 return userVerbose?.organizationName || userVerbose?.userSegments?.homeSegmentName;
             }
@@ -199,9 +197,7 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
         ((selectedUserType === USER_TYPES.BUSINESS || selectedUserType === USER_TYPES.COMMUNITY)
             ? (formData.get('inputOrg') as string)
             : undefined);
-        
-        console.log(orgName)
-    
+            
         const registerData: IRegisterInput = {
             userRoleId: undefined,
             email: formData.get('inputEmail') as string,

--- a/frontend/src/components/content/UserManagementContent.tsx
+++ b/frontend/src/components/content/UserManagementContent.tsx
@@ -176,11 +176,12 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
         if (user?.userType === USER_TYPES.SUPER_ADMIN || 
             user?.userType === USER_TYPES.ADMIN || 
             user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN) {
+            console.log(user?.userType)
       
             // If selected user type is MUNICIPAL or parent is MUNICIPAL_SEG_ADMIN
             if (selectedUserType === USER_TYPES.MUNICIPAL || 
               user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN) {
-      
+                console.log("userType:", user?.userType)
                 // Return organization name of the parent user, or fallback to home segment name
                 return userVerbose?.organizationName || userVerbose?.userSegments?.homeSegmentName;
             }
@@ -194,9 +195,12 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
         const form = event.target as HTMLFormElement;
         const formData = new FormData(form);
         
-        const orgName = getOrganizationName(user, selectedUserType, userVerbose) ?? 
-                        (selectedUserType === USER_TYPES.BUSINESS || selectedUserType === USER_TYPES.COMMUNITY) ? 
-                        formData.get('inputOrg') as string : undefined;
+        const orgName = getOrganizationName(user, selectedUserType, userVerbose) ??
+        ((selectedUserType === USER_TYPES.BUSINESS || selectedUserType === USER_TYPES.COMMUNITY)
+            ? (formData.get('inputOrg') as string)
+            : undefined);
+        
+        console.log(orgName)
     
         const registerData: IRegisterInput = {
             userRoleId: undefined,

--- a/frontend/src/components/content/UserManagementContent.tsx
+++ b/frontend/src/components/content/UserManagementContent.tsx
@@ -171,23 +171,23 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
         user: IUser | null, 
         selectedUserType: string, 
         userVerbose: IUser | null | undefined
-      ): string | undefined => {
+    ): string | undefined => {
         // Check if the user is a SUPER_ADMIN, ADMIN, or MUNICIPAL_SEG_ADMIN
         if (user?.userType === USER_TYPES.SUPER_ADMIN || 
             user?.userType === USER_TYPES.ADMIN || 
             user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN) {
       
-          // If selected user type is MUNICIPAL or parent is MUNICIPAL_SEG_ADMIN
-          if (selectedUserType === USER_TYPES.MUNICIPAL || 
+            // If selected user type is MUNICIPAL or parent is MUNICIPAL_SEG_ADMIN
+            if (selectedUserType === USER_TYPES.MUNICIPAL || 
               user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN) {
       
-            // Return organization name of the parent user, or fallback to home segment name
-            return userVerbose?.organizationName || userVerbose?.userSegments?.homeSegmentName;
-          }
+                // Return organization name of the parent user, or fallback to home segment name
+                return userVerbose?.organizationName || userVerbose?.userSegments?.homeSegmentName;
+            }
         }
       
         return undefined; 
-      };
+    };
       
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();

--- a/frontend/src/components/content/UserManagementContent.tsx
+++ b/frontend/src/components/content/UserManagementContent.tsx
@@ -321,8 +321,6 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
                     user.userType !== USER_TYPES.MUNICIPAL_SEG_ADMIN &&
                     user.userType !== USER_TYPES.SEG_ADMIN
                 );
-                console.log(filteredUsers);
-                console.log(user);
                 setFilteredUsers(filteredUsers);
             }
         };

--- a/frontend/src/components/content/UserManagementContent.tsx
+++ b/frontend/src/components/content/UserManagementContent.tsx
@@ -174,14 +174,14 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
     ): string | undefined => {
         switch(selectedUserType) {
             case USER_TYPES.BUSINESS || USER_TYPES.COMMUNITY: {
-                return formData.get('inputOrg') as string
+                return formData.get('inputOrg') as string;
             }
             case USER_TYPES.MUNICIPAL: {
-                return formData.get('inputCom') as string
+                return formData.get('inputCom') as string;
             }
         }
-        return undefined
-    }
+        return undefined;
+    };
 
     const getOrganizationName = (
         user: IUser | null, 
@@ -192,7 +192,7 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
         // Check the type of user creating the account, since the wizards display different fields
         switch(user?.userType){
             case USER_TYPES.ADMIN || USER_TYPES.SUPER_ADMIN: {
-                return getOrganizationNameAdmin(selectedUserType, formData)
+                return getOrganizationNameAdmin(selectedUserType, formData);
             }
 
             // Return the municipal seg admin's organization name or fallback to their homeSegmentName if an org name is not set.
@@ -207,7 +207,7 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
         event.preventDefault();
         const form = event.target as HTMLFormElement;
         const formData = new FormData(form);
-        const orgName = getOrganizationName(user, userVerbose, selectedUserType,  formData)
+        const orgName = getOrganizationName(user, userVerbose, selectedUserType,  formData);
             
         const registerData: IRegisterInput = {
             userRoleId: undefined,

--- a/frontend/src/components/content/UserManagementContent.tsx
+++ b/frontend/src/components/content/UserManagementContent.tsx
@@ -20,6 +20,7 @@ import { ISegment, ISuperSegment } from 'src/lib/types/data/segment.type';
 import { EditUserInfoModal } from '../modal/EditUserInfoModal';
 import UserChangePasswordModal from '../modal/UserChangePasswordModal';
 import { postUserSegmentInfo } from 'src/lib/api/userSegmentRoutes';
+import { unendorseIdeaByUser } from 'src/lib/api/ideaRoutes';
 
 interface UserManagementContentProps {
     users: IUser[] | undefined;
@@ -167,24 +168,38 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
         }
     };
 
+    const getOrganizationNameAdmin = ( 
+        selectedUserType: string, 
+        formData: FormData
+    ): string | undefined => {
+        switch(selectedUserType) {
+            case USER_TYPES.BUSINESS || USER_TYPES.COMMUNITY: {
+                return formData.get('inputOrg') as string
+            }
+            case USER_TYPES.MUNICIPAL: {
+                return formData.get('inputCom') as string
+            }
+        }
+        return undefined
+    }
+
     const getOrganizationName = (
         user: IUser | null, 
+        userVerbose: IUser | null | undefined,
         selectedUserType: string, 
-        userVerbose: IUser | null | undefined
+        formData: FormData
     ): string | undefined => {
-        // Check if the user is a SUPER_ADMIN, ADMIN, or MUNICIPAL_SEG_ADMIN
-        if (user?.userType === USER_TYPES.SUPER_ADMIN || 
-            user?.userType === USER_TYPES.ADMIN || 
-            user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN) {
-      
-            // If selected user type is MUNICIPAL or parent is MUNICIPAL_SEG_ADMIN
-            if (selectedUserType === USER_TYPES.MUNICIPAL || 
-              user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN) {
-                // Return organization name of the parent user, or fallback to home segment name
+        // Check the type of user creating the account, since the wizards display different fields
+        switch(user?.userType){
+            case USER_TYPES.ADMIN || USER_TYPES.SUPER_ADMIN: {
+                return getOrganizationNameAdmin(selectedUserType, formData)
+            }
+
+            // Return the municipal seg admin's organization name or fallback to their homeSegmentName if an org name is not set.
+            case USER_TYPES.MUNICIPAL_SEG_ADMIN: {
                 return userVerbose?.organizationName || userVerbose?.userSegments?.homeSegmentName;
             }
         }
-      
         return undefined; 
     };
       
@@ -192,11 +207,7 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
         event.preventDefault();
         const form = event.target as HTMLFormElement;
         const formData = new FormData(form);
-        
-        const orgName = getOrganizationName(user, selectedUserType, userVerbose) ??
-        ((selectedUserType === USER_TYPES.BUSINESS || selectedUserType === USER_TYPES.COMMUNITY)
-            ? (formData.get('inputOrg') as string)
-            : undefined);
+        const orgName = getOrganizationName(user, userVerbose, selectedUserType,  formData)
             
         const registerData: IRegisterInput = {
             userRoleId: undefined,

--- a/frontend/src/components/content/UserManagementContent.tsx
+++ b/frontend/src/components/content/UserManagementContent.tsx
@@ -167,21 +167,43 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
         }
     };
 
+    const getOrganizationName = (
+        user: IUser | null, 
+        selectedUserType: string, 
+        userVerbose: IUser | null | undefined
+      ): string | undefined => {
+        // Check if the user is a SUPER_ADMIN, ADMIN, or MUNICIPAL_SEG_ADMIN
+        if (user?.userType === USER_TYPES.SUPER_ADMIN || 
+            user?.userType === USER_TYPES.ADMIN || 
+            user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN) {
+      
+          // If selected user type is MUNICIPAL or parent is MUNICIPAL_SEG_ADMIN
+          if (selectedUserType === USER_TYPES.MUNICIPAL || 
+              user?.userType === USER_TYPES.MUNICIPAL_SEG_ADMIN) {
+      
+            // Return organization name of the parent user, or fallback to home segment name
+            return userVerbose?.organizationName || userVerbose?.userSegments?.homeSegmentName;
+          }
+        }
+      
+        return undefined; 
+      };
+      
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         const form = event.target as HTMLFormElement;
         const formData = new FormData(form);
-
+        
+        const orgName = getOrganizationName(user, selectedUserType, userVerbose) ?? 
+                        (selectedUserType === USER_TYPES.BUSINESS || selectedUserType === USER_TYPES.COMMUNITY) ? 
+                        formData.get('inputOrg') as string : undefined;
+    
         const registerData: IRegisterInput = {
             userRoleId: undefined,
             email: formData.get('inputEmail') as string,
             password: formData.get('inputPassword') as string,
             confirmPassword: formData.get('inputPassword') as string,
-            organizationName: (user?.userType === USER_TYPES.SUPER_ADMIN || user?.userType === USER_TYPES.ADMIN)
-                && (
-                    selectedUserType === USER_TYPES.BUSINESS ||
-                    selectedUserType === USER_TYPES.COMMUNITY
-                ) ? formData.get('inputOrg') as string : undefined,
+            organizationName: orgName,
             fname: formData.get('inputFirst') as string,
             lname: formData.get('inputLast') as string,
             displayFName: formData.get('inputFirst') as string,
@@ -212,7 +234,6 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
                 faculty: '',
                 programCompletionDate: new Date(),
             },
-
             homeSegmentId: userVerbose?.userType === USER_TYPES.SUPER_ADMIN || userVerbose?.userType === USER_TYPES.ADMIN ? newHomeID : userVerbose?.userSegments?.homeSegmentId,
             workSegmentId: userVerbose?.userType === USER_TYPES.SUPER_ADMIN || userVerbose?.userType === USER_TYPES.ADMIN ? newWorkID : undefined,
             schoolSegmentId: userVerbose?.userType === USER_TYPES.SUPER_ADMIN || userVerbose?.userType === USER_TYPES.ADMIN ? newSchoolID : undefined,
@@ -223,7 +244,6 @@ export const UserManagementContent: React.FC<UserManagementContentProps> = ({ us
             reachSegmentIds: [],
             verified: true,
         };
-
 
         try {
             if (await getUserWithEmail(registerData.email) === 200) {

--- a/frontend/src/components/partials/SingleIdeaContent/EndorsedUsersSection.tsx
+++ b/frontend/src/components/partials/SingleIdeaContent/EndorsedUsersSection.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
 import {
     Card,
-    Table, 
+    Table,
 } from 'react-bootstrap';
+import { USER_TYPES } from 'src/lib/constants';
 
 interface EndorsedUsersSectionProps {
-  endorsedUsers: any[];
+    endorsedUsers: any[];
 }
 
 const EndorsedUsersSection: React.FC<EndorsedUsersSectionProps> = ({ endorsedUsers }) => {
@@ -21,20 +22,22 @@ const EndorsedUsersSection: React.FC<EndorsedUsersSectionProps> = ({ endorsedUse
                     </div>
                 </Card.Header>
                 <Card.Body>
-                    <Table style={{margin: '0rem'}}>
+                    <Table style={{ margin: '0rem' }}>
                         <tbody>
                             {endorsedUsers.map((user) => (
                                 <tr key={user.id}>
                                     <td>
-                                        {user.organizationName || `${user.userType} Endorser - No Affiliated Organization.` } 
+                                        {[USER_TYPES.MUNICIPAL, USER_TYPES.MUNICIPAL_SEG_ADMIN].includes(user.userType)
+                                            ? `Municipality of ${user.organizationName}`
+                                            : user.organizationName || `${user.userType} Endorser - No Affiliated Organization.`}
                                     </td>
                                 </tr>
-                            ))
-                            }
+                            ))}
                         </tbody>
+
                     </Table>
                 </Card.Body>
-            </Card>   
+            </Card>
         </div>
     );
 };

--- a/server/prisma/migrations/20240626203401_update_idea_comment_comment_funnel/migration.sql
+++ b/server/prisma/migrations/20240626203401_update_idea_comment_comment_funnel/migration.sql
@@ -29,7 +29,7 @@ ALTER TABLE "public_community_business_profile" DROP CONSTRAINT "public_communit
 ALTER TABLE "public_municipal_profile" DROP CONSTRAINT "public_municipal_profile_userId_fkey";
 
 -- DropForeignKey
---ALTER TABLE "quarantine_notifications" DROP CONSTRAINT "quarantine_notifications_ideaId_ideaTitle_fkey"; manual fix of migration issue
+ALTER TABLE "quarantine_notifications" DROP CONSTRAINT "quarantine_notifications_ideaId_ideaTitle_fkey"; 
 
 -- DropForeignKey
 ALTER TABLE "quarantine_notifications" DROP CONSTRAINT "quarantine_notifications_userId_fkey";


### PR DESCRIPTION
This changes a few things and should have just been multiple branches, but 🤡 <- me

**Properly setting organizationName/municipality**
- Municipal seg admins now have their organizationName set to whatever their home segment name is. 
- All municipal users created by a Municipal Segment Admin will have their organizationName set to the admin's organizationName, or the admin's home segment name as a fallback
- All municipal users created by a Super admin or Admin will have their organizationName set to the home segment name selected by the admin in the creation wizard

**Endorsements**
- Restricted endorsement button so only one member of an organization can endorse a proposal or idea. 
- Added tooltip to the disabled endorse button notifying user that the idea has been endorsed by their org already
- Prevented unendorsement of an idea/proposal except by the user who endorsed it (may need to be changed in the future)
