### PR TITLE
Fix/nonresidents cannot submit ideas to proposals/harrison

### DIFF
--- a/frontend/src/components/content/SingleProposalPageContent.tsx
+++ b/frontend/src/components/content/SingleProposalPageContent.tsx
@@ -172,11 +172,11 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
     const [showProposalSegmentError, setShowProposalSegmentError] = useState(false);
 
     function redirectToIdeaSubmit() {
-        if (userType === 'RESIDENT') {
+        if (userType === 'Resident') {
             let name = subSegment?.name;
 
             if (name && subSegment) {
-                if (subSegment.segId === userSegmentData.homeSubSegmentId || subSegment.segId === userSegmentData.workSubSegmentId || subSegment.segId === userSegmentData.schoolSubSegmentId) {
+                if (subSegment.id === userSegmentData.homeSubSegmentId || subSegment.id === userSegmentData.workSubSegmentId || subSegment.id === userSegmentData.schoolSubSegmentId) {
                     const communityOfInterest = getSegmentName(name);
                     window.location.href = `/submit?supportedProposal=${proposalId}&communityOfInterest=${communityOfInterest}`;
                 } else {

--- a/frontend/src/components/partials/SuggestedIdeasTable.tsx
+++ b/frontend/src/components/partials/SuggestedIdeasTable.tsx
@@ -53,7 +53,7 @@ export const SuggestedIdeasTable: React.FC<any> = (props) => {
                                             ? `${suggestion?.author?.userSegments?.homeSegHandle} As Resident`
                                             : Number(suggestion?.subSegment?.id) === suggestion?.author?.userSegments?.workSubSegmentId
                                                 ? suggestion?.author?.userSegments?.workSegHandle || `${suggestion?.author?.userSegments?.homeSegHandle} As Worker`
-                                                : Number(suggestion?.subSegment?.id) === suggestion?.author?.userSegments?.schoolSubSegmentID
+                                                : Number(suggestion?.subSegment?.id) === suggestion?.author?.userSegments?.schoolSubSegmentId
                                                     ? `${suggestion?.author?.userSegments?.schoolSegHandle} As Student`
                                                     : `${suggestion?.author?.userSegments?.homeSegHandle} As Resident`
                                     ) : Number(suggestion?.segment?.segId) ? (


### PR DESCRIPTION
Fixed check in frontend/src/components/content/SingleProposalPageContent.tsx  redirectToIdeaSubmit function to check for 'Resident' Instead of "RESIDENT'. Also fixed bug incorrectly checking subSeg Id's against the idea subSegment.segId to against the idea SubSegment.id. As well as fixed a type causing student handles to be shown as resident handle in SuggestedIdeasTable.tsx component