### PR TITLE
Add clickable author names on Proposals and Ideas to navigate to public profiles

### DIFF
--- a/frontend/src/components/content/SingleIdeaPageContent.tsx
+++ b/frontend/src/components/content/SingleIdeaPageContent.tsx
@@ -8,6 +8,7 @@ import {
     capitalizeString,
     getIdeaSegmentsMap,
 } from '../../lib/utilityFunctions';
+import { useHistory } from 'react-router-dom';
 import CommentsSection from '../partials/SingleIdeaContent/CommentsSection';
 import RatingsSection from '../partials/SingleIdeaContent/RatingsSection';
 import {
@@ -122,6 +123,7 @@ const SingleIdeaPageContent: React.FC<SingleIdeaPageContentProps> = ({
 
     // API hooks for this component
     const { user, token } = useContext(UserProfileContext);
+    const history = useHistory();
     const { data: isFollowingPost, isLoading: isFollowingPostLoading } = useCheckIdeaFollowedByUser(token, (user ? user.id : user), ideaId);
     const { data: isEndorsingPost, isLoading: isEndorsingPostLoading } = useCheckIdeaEndorsedByUser(token, (user ? user.id : user), ideaId);
     const { data: endorsedUsersData, isLoading: isEndorsedUsersDataLoading } = useGetEndorsedUsersByIdea(token, ideaId);
@@ -268,6 +270,30 @@ const SingleIdeaPageContent: React.FC<SingleIdeaPageContentProps> = ({
             setFollowingPost(!followingPost);
         }
     };
+
+    const handleAuthorClick = () => {
+        if (!author) return;
+        
+        const transformedProfile = {
+            statement: '',
+            contactEmail: '',
+            contactPhone: '',
+            address: author.address?.streetAddress || '',
+            links: [],
+            responsibility: author.userType === USER_TYPES.MUNICIPAL ? '' : undefined,
+            description: author.userType !== USER_TYPES.MUNICIPAL ? '' : undefined,
+            user: {
+                id: author.id,
+                fname: author.fname || '',
+                lname: author.lname || '',
+                userType: author.userType,
+                organizationName: author.organizationName || ''
+            }
+        };
+        
+        history.push('/profile-card-display', { publicProfile: transformedProfile });
+    };
+
     if (!active) {
         return (
             <div>Idea Is Currently Inactive</div>
@@ -572,6 +598,14 @@ const SingleIdeaPageContent: React.FC<SingleIdeaPageContentProps> = ({
                     text-decoration:underline;
                     color: grey;
                   }
+                  .author-link {
+                    cursor: pointer;
+                    transition: color 0.2s;
+                  }
+                  .author-link:hover {
+                    color: #549762;
+                    text-decoration: underline;
+                  }
                   `}
                                     </style>
 
@@ -722,8 +756,10 @@ const SingleIdeaPageContent: React.FC<SingleIdeaPageContentProps> = ({
                                     author?.userSegments?.find( seg => seg.userSegmentRelationship === UserSegmentRelationshipEnum.HOME)?.segmentId == primarySegment?.segId &&
                                     (
                                         <div>
-                                            {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.HOME)?.handle ?? 
-                                            `${author?.fname}@${author?.address?.streetAddress}`} as Resident
+                                            <span className='author-link' onClick={handleAuthorClick}>
+                                                {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.HOME)?.handle ?? 
+                                                `${author?.fname}@${author?.address?.streetAddress}`}
+                                            </span> as Resident
                                         </div>
                                     ) ||
 
@@ -731,14 +767,18 @@ const SingleIdeaPageContent: React.FC<SingleIdeaPageContentProps> = ({
 
                                     (
                                         <div>
-                                            {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.SCHOOL)?.handle} as Student
+                                            <span className='author-link' onClick={handleAuthorClick}>
+                                                {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.SCHOOL)?.handle}
+                                            </span> as Student
                                         </div>
                                     ) ||
 
                                     author?.userSegments?.find( seg => seg.userSegmentRelationship === UserSegmentRelationshipEnum.WORK)?.segmentId == primarySegment?.segId &&
                                     (
                                         <div>
-                                            {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.WORK)?.handle} as Worker
+                                            <span className='author-link' onClick={handleAuthorClick}>
+                                                {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.WORK)?.handle}
+                                            </span> as Worker
                                         </div>
                                     )
                                 }

--- a/frontend/src/components/content/SingleProposalPageContent.tsx
+++ b/frontend/src/components/content/SingleProposalPageContent.tsx
@@ -17,6 +17,7 @@ import {
     capitalizeString,
     getIdeaSegmentsMap,
 } from '../../lib/utilityFunctions';
+import { useHistory } from 'react-router-dom';
 import LoadingSpinnerInline from '../ui/LoadingSpinnerInline';
 import CommentsSection from '../partials/SingleIdeaContent/CommentsSection';
 import RatingsSection from '../partials/SingleIdeaContent/RatingsSection';
@@ -229,6 +230,7 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
     const { token, user } = useContext(UserProfileContext);
     const { data: userSegmentData, isLoading: userSegementLoading } = useAllUserSegments(token, user?.id || null);
     const { data: useAllIdeaData, isLoading: useAllIdeaLoading } = useAllIdeas();
+    const history = useHistory();
 
 
     const [isLoading, setIsLoading] = useState(false);
@@ -497,6 +499,29 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
         isPostAuthor = author!.id === user!.id;
     }
 
+    const handleAuthorClick = () => {
+        if (!author) return;
+        
+        const transformedProfile = {
+            statement: '',
+            contactEmail: '',
+            contactPhone: '',
+            address: author.address?.streetAddress || '',
+            links: [],
+            responsibility: author.userType === USER_TYPES.MUNICIPAL ? '' : undefined,
+            description: author.userType !== USER_TYPES.MUNICIPAL ? '' : undefined,
+            user: {
+                id: author.id,
+                fname: author.fname || '',
+                lname: author.lname || '',
+                userType: author.userType,
+                organizationName: author.organizationName || ''
+            }
+        };
+        
+        history.push('/profile-card-display', { publicProfile: transformedProfile });
+    };
+
     const flagFunc = async (ideaId: number, token: string, userId: string, ideaActive: boolean, reason: string, quarantined_at: Date) => {
         await createFlagUnderIdea(ideaId, reason, token!);
         const thresholdExceeded = await compareIdeaFlagsWithThreshold(ideaId, token!);
@@ -555,6 +580,14 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
           cursor: pointer;
           text-decoration:underline;
           color: grey;
+        }
+        .author-link {
+          cursor: pointer;
+          transition: color 0.2s;
+        }
+        .author-link:hover {
+          color: #549762;
+          text-decoration: underline;
         }
         `}
             </style>
@@ -847,8 +880,10 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
                                     author?.userSegments?.find( seg => seg.userSegmentRelationship === UserSegmentRelationshipEnum.HOME)?.segmentId == primarySegment?.segId &&
                                     (
                                         <div>
-                                            {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.HOME)?.handle ?? 
-                                            `${author?.fname}@${author?.address?.streetAddress}`} as Resident
+                                            <span className='author-link' onClick={handleAuthorClick}>
+                                                {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.HOME)?.handle ?? 
+                                                `${author?.fname}@${author?.address?.streetAddress}`}
+                                            </span> as Resident
                                         </div>
                                     ) ||
 
@@ -856,14 +891,18 @@ const SingleProposalPageContent: React.FC<SingleIdeaPageContentProps> = ({
 
                                     (
                                         <div>
-                                            {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.SCHOOL)?.handle} as Student
+                                            <span className='author-link' onClick={handleAuthorClick}>
+                                                {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.SCHOOL)?.handle}
+                                            </span> as Student
                                         </div>
                                     ) ||
 
                                     author?.userSegments?.find( seg => seg.userSegmentRelationship === UserSegmentRelationshipEnum.WORK)?.segmentId == primarySegment?.segId &&
                                     (
                                         <div>
-                                            {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.WORK)?.handle} as Worker
+                                            <span className='author-link' onClick={handleAuthorClick}>
+                                                {author?.userHandles?.find( h => h.userSegmentRelationship === UserSegmentRelationshipEnum.WORK)?.handle}
+                                            </span> as Worker
                                         </div>
                                     )
                                 }

--- a/frontend/src/pages/ProfileCardDisplayPage.tsx
+++ b/frontend/src/pages/ProfileCardDisplayPage.tsx
@@ -60,8 +60,8 @@ const ProfileCardDisplayPage: React.FC = () => {
     const endorsedProposalTotalPages = Math.ceil(endorsedProposalIdeas.length / 6);
 
     const handleBackToCards = () => {
-        // Navigate back to the public profiles page
-        history.push(ROUTES.PUBLIC_PROFILES);
+        // Navigate back to the previous page
+        history.goBack();
     };
 
     // Fetch full profile data when component mounts
@@ -150,7 +150,7 @@ const ProfileCardDisplayPage: React.FC = () => {
             <Row className='mb-4'>
                 <Col>
                     <Button variant='secondary' onClick={handleBackToCards}>
-                        ← Back to Public Profiles
+                        ← Back
                     </Button>
                 </Col>
             </Row>


### PR DESCRIPTION
Minor requested changes from Nic. 

Made the names on the ideas and proposals clickable and then it navigates the user to the ProfileCardDisplayPage, which displays the authors information.

Currently no adjustment based on user requested privacy. That would require changes to the schema and at this stage of the project, poses too much risk. 